### PR TITLE
Stack overflow with JavaTokenParsers.stringLiteral

### DIFF
--- a/src/main/scala/scala/util/parsing/combinator/JavaTokenParsers.scala
+++ b/src/main/scala/scala/util/parsing/combinator/JavaTokenParsers.scala
@@ -49,7 +49,7 @@ trait JavaTokenParsers extends RegexParsers {
    */
   @migration("`stringLiteral` allows escaping single and double quotes, but not forward slashes any longer.", "2.10.0")
   def stringLiteral: Parser[String] =
-    ("\""+"""([^"\p{Cntrl}\\]|\\[\\'"bfnrt]|\\u[a-fA-F0-9]{4})*"""+"\"").r
+    ("\""+"""([^"\p{Cntrl}\\]|\\[\\'"bfnrt]|\\u[a-fA-F0-9]{4})*+"""+"\"").r
   /** A number following the rules of `decimalNumber`, with the following
    *  optional additions:
    *


### PR DESCRIPTION
The regular expression that is used to match stringLiterals cannot match strings longer than about 2500 characters. You might wonder why this would be required, still it isn't possible.

A very minor change to make the regext possessive fixes the problem, and won't cause any regressions, as backtracking is not possible in the regex anyway.
