### PR TITLE
Test locally built scala parser-combinators classes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,9 @@ scalaModuleOsgiSettings
 
 OsgiKeys.exportPackage := Seq(s"scala.util.parsing.*;version=${version.value}")
 
+// needed to fix classloader issues (see scala-xml#20)
+fork in Test := true
+
 libraryDependencies += "junit" % "junit" % "4.11" % "test"
 
 libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test"


### PR DESCRIPTION
Somehow, the scala-parser-combinators classes used to run tests were
not the local ones, even though there is no dependency on scala-compiler
nor on anything that depends on scala-parser-combinators.

After some head-scratching, I discovered scala/scala-xml#20. Now I am even
more confused, but at least `fork in Test := true` does prevent this
evil classloader magic.
