### PR TITLE
Version bumps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 script:
   - sbt ++$TRAVIS_SCALA_VERSION clean update compile test
 scala:
-  - 2.11.0-SNAPSHOT
+  - 2.11.0
 jdk:
   - openjdk6
   - openjdk7

--- a/build.sbt
+++ b/build.sbt
@@ -4,11 +4,11 @@ scalaModuleSettings
 
 name                       := "scala-parser-combinators"
 
-version                    := "1.0.1-SNAPSHOT"
+version                    := "1.0.2-SNAPSHOT"
 
-scalaVersion               := "2.11.0-RC1"
+scalaVersion               := "2.11.0"
 
-snapshotScalaBinaryVersion := "2.11.0-RC1"
+snapshotScalaBinaryVersion := "2.11"
 
 // important!! must come here (why?)
 scalaModuleOsgiSettings
@@ -24,7 +24,7 @@ libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test"
 
 MimaPlugin.mimaDefaultSettings
 
-MimaKeys.previousArtifact := Some(organization.value % s"${name.value}_2.11.0-RC1" % "1.0.0")
+MimaKeys.previousArtifact := Some(organization.value % s"${name.value}_2.11" % "1.0.1")
 
 // run mima during tests
 test in Test := {


### PR DESCRIPTION
- Update project version to 1.0.2-SNAPSHOT, give that 1.0.1 is
  already released
  - Use _2.11 as the snapshot binary version for 2.12.0-SNAPSHOT
    PR validation.
  - Use 1.0.1 as the MiMa baseline
  - Use Scala 2.11.0 for Travis CI builds
