### PR TITLE
Prepare 1.0.2 release and bump to 1.0.3-SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ scalaModuleSettings
 
 name                       := "scala-parser-combinators"
 
-version                    := "1.0.2-SNAPSHOT"
+version                    := "1.0.3-SNAPSHOT"
 
 scalaVersion               := "2.11.1"
 


### PR DESCRIPTION
v1.0.2 is tagged. Bumping version number to 1.0.3-SNAPSHOT.
## 

v1.0.2 contains only two bug fix:
- [SI-7710](https://issues.scala-lang.org/browse/SI-7710) fix memory performance of RegexParsers in jdk7u6+ -- 91584dc
- [SI-4824](https://issues.scala-lang.org/browse/SI-4824) Fixes stack overflow bug when parsing long multiline comments -- f326847
