### PR TITLE
Revert to sbt 0.13.2

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.2


### PR DESCRIPTION
sbt 0.13.5 broke a hack in our release scripts
(Confirmed by successful run using v1.0.1, which was on 0.13.1:
https://scala-webapps.epfl.ch/jenkins/job/scala-release-2.11.x/139/
previous builds have been red.)

Let's revert until we can come up with a fix for the script.

review by @gourlaysama, /cc @lrytz
