### PR TITLE
Removed JSON deprecation warnings

### DIFF
--- a/src/main/scala/scala/util/parsing/json/JSON.scala
+++ b/src/main/scala/scala/util/parsing/json/JSON.scala
@@ -28,12 +28,10 @@ package util.parsing.json
  *
  * @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
-@deprecated("This object will be removed.", "2.11.0")
 object JSON extends Parser {
 
   /**
-   * This method converts ''raw'' results back into the original, deprecated
-   * form.
+   * This method converts ''raw'' results back into the original form.
    */
   private def unRaw (in : Any) : Any = in match {
     case JSONObject(obj) => obj.map({ case (k,v) => (k,unRaw(v))}).toList

--- a/src/main/scala/scala/util/parsing/json/Lexer.scala
+++ b/src/main/scala/scala/util/parsing/json/Lexer.scala
@@ -18,7 +18,6 @@ import scala.util.parsing.input.CharArrayReader.EofCh
 /**
  *  @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
-@deprecated("This class will be removed.", "2.11.0")
 class Lexer extends StdLexical with ImplicitConversions {
 
   override def token: Parser[Token] =

--- a/src/main/scala/scala/util/parsing/json/Parser.scala
+++ b/src/main/scala/scala/util/parsing/json/Parser.scala
@@ -19,7 +19,6 @@ import scala.util.parsing.combinator.syntactical._
  *
  *  @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
-@deprecated("This class will be removed.", "2.11.0")
 sealed abstract class JSONType {
   /**
    * This version of toString allows you to provide your own value
@@ -41,7 +40,6 @@ sealed abstract class JSONType {
  *
  * @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
-@deprecated("This object will be removed.", "2.11.0")
 object JSONFormat {
   /**
    * This type defines a function that can be used to
@@ -93,7 +91,6 @@ object JSONFormat {
  *
  *  @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
-@deprecated("This class will be removed.", "2.11.0")
 case class JSONObject (obj : Map[String,Any]) extends JSONType {
   def toString (formatter : JSONFormat.ValueFormatter) =
     "{" + obj.map({ case (k,v) => formatter(k.toString) + " : " + formatter(v) }).mkString(", ") + "}"
@@ -103,7 +100,6 @@ case class JSONObject (obj : Map[String,Any]) extends JSONType {
  *  Represents a JSON Array (list).
  *  @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
-@deprecated("This class will be removed.", "2.11.0")
 case class JSONArray (list : List[Any]) extends JSONType {
   def toString (formatter : JSONFormat.ValueFormatter) =
     "[" + list.map(formatter).mkString(", ") + "]"
@@ -114,7 +110,6 @@ case class JSONArray (list : List[Any]) extends JSONType {
  *
  *  @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
-@deprecated("This class will be removed.", "2.11.0")
 class Parser extends StdTokenParsers with ImplicitConversions {
   // Fill in abstract defs
   type Tokens = Lexer


### PR DESCRIPTION
Removes the deprecation warnings which were added to JSON objects and classes prior to their removal from the Scala standard library. Now that this project has been branched into a separate module, the deprecation warnings can be removed.
