### PR TITLE
SI-8879 fix quadratic reading time in StreamReader

### DIFF
--- a/src/test/scala/scala/util/parsing/combinator/t8879.scala
+++ b/src/test/scala/scala/util/parsing/combinator/t8879.scala
@@ -1,0 +1,42 @@
+import scala.util.parsing.input._
+import scala.collection.immutable.PagedSeq
+
+import org.junit.Test
+import org.junit.Assert.fail
+
+class t8879 {
+
+  @Test
+  def test: Unit = {
+     val testPagedSeq = {
+       var nbpage = 0
+       def more(data: Array[Char], start: Int, len: Int): Int = {
+         if (nbpage < 1) {
+           var i = 0
+           while (i < len && nbpage < 3) {
+             if (i % 100 != 0) {
+               data(start + i) = 'a'
+             } else {
+               data(start + i) = '\n'
+             }
+             i += 1
+           }
+           if (i == 0) -1 else {
+             nbpage += 1
+             i
+           }
+         } else {
+           fail("Should not read more than 1 page!")
+           0
+         }
+       }
+
+       new PagedSeq(more(_: Array[Char], _: Int, _: Int))
+     }
+
+     val s = new StreamReader(testPagedSeq, 0, 1)
+
+     // should not trigger reading of the second page
+     s.drop(20)
+  }
+}


### PR DESCRIPTION
`StreamReader.nextEol` used to loop all the way to Eol every time an
element was read. That's very costly when lines are long.

Furthermore, it used to call `PagedSeq.length`, forcing `PagedSeq` to
load the whole input in memory, even when a single character was read.

`nextEol` is now saved as part of the state of `StreamReader`, and is passed
to child readers when created (as long as we do not read past the end of
the line). Thus it computed only once per line, whatever the length.

With the example in the ticket (SI-8879), we get:
- before:

```
    User time (seconds): 82.12
    System time (seconds): 0.07
    Elapsed (wall clock) time (h:mm:ss or m:ss): 1:21.52
```
- after:

```
    User time (seconds): 1.05
    System time (seconds): 0.06
    Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.68
```
- for comparison, using PagedSeqReader directly:

```
    User time (seconds): 1.06
    System time (seconds): 0.06
    Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.69
```

`isDefinedAt` is used instead of `length` so that pages beyond the
tested index do not need to be read. The test only tests this part.
