### PR TITLE
Revert "make RegexParser.err handle whitespace like literal and regex."

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import com.typesafe.tools.mima.plugin.{MimaPlugin, MimaKeys}
-import com.typesafe.tools.mima.core.{ProblemFilters, MissingMethodProblem}
 
 scalaModuleSettings
 
@@ -32,5 +31,3 @@ test in Test := {
         MimaKeys.reportBinaryIssues.value
         (test in Test).value
 }
-
-MimaKeys.binaryIssueFilters += ProblemFilters.exclude[MissingMethodProblem]("scala.util.parsing.combinator.RegexParsers.scala$util$parsing$combinator$RegexParsers$$super$err")

--- a/src/main/scala/scala/util/parsing/combinator/RegexParsers.scala
+++ b/src/main/scala/scala/util/parsing/combinator/RegexParsers.scala
@@ -137,22 +137,6 @@ trait RegexParsers extends Parsers {
     }
   }
 
-  // we might want to make it public/protected in a future version
-  private def ws[T](p: Parser[T]): Parser[T] = new Parser[T] {
-    def apply(in: Input) = {
-      val offset = in.offset
-      val start = handleWhiteSpace(in.source, offset)
-      p(in.drop (start - offset))
-    }
-  }
-
-  /**
-   * @inheritdoc
-   *
-   * This parser additionnal skips whitespace if `skipWhitespace` returns true.
-   */
-  override def err(msg: String) = ws(super.err(msg))
-
   override def phrase[T](p: Parser[T]): Parser[T] =
     super.phrase(p <~ opt("""\z""".r))
 

--- a/src/test/scala/scala/util/parsing/combinator/RegexParsersTest.scala
+++ b/src/test/scala/scala/util/parsing/combinator/RegexParsersTest.scala
@@ -1,7 +1,7 @@
 package scala.util.parsing.combinator
 
 import org.junit.Test
-import org.junit.Assert.{assertEquals,assertTrue}
+import org.junit.Assert.assertEquals
 
 class RegexParsersTest {
   @Test
@@ -72,20 +72,5 @@ class RegexParsersTest {
 
     val success = parseAll(twoWords, "first second").asInstanceOf[Success[(String, String)]]
     assertEquals(("second", "first"), success.get)
-  }
-
-  @Test
-  def errorConsumesWhitespace: Unit = {
-    object parser extends RegexParsers {
-      def num = "\\d+".r
-
-      def twoNums =  num ~ (num | err("error!"))
-    }
-    import parser._
-
-    // this used to return a Failure (for the second num)
-    val error = parseAll(twoNums, "458   bar")
-    assertTrue(s"expected an Error but got: ${error.getClass.getName}", error.isInstanceOf[Error])
-    assertEquals("error!", error.asInstanceOf[Error].msg)
   }
 }


### PR DESCRIPTION
Reverts scala/scala-parser-combinators#30 (dc9e9cf), because it isn't binary compatible with `1.0.2`. Mima did catch it, this was human error (mine).

The plan is:
- `1.0.3` gets released with this PR (so without the fix),
- `master` becomes `1.1.0-SNAPSHOT` and the fix is reapplied. That version isn't binary compatible with the `1.0` versions, so it cannot be bundled with 2.11,
- a `1.0.x` branches is created for a possible `1.0.4`, for binary compatible changes.
