### PR TITLE
Bump version to 1.1.0-SNAPSHOT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 script:
   - admin/build.sh
 scala:
-  - 2.11.2
+  - 2.11.4
 jdk:
   - openjdk6
   - openjdk7

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,11 @@
-import com.typesafe.tools.mima.plugin.{MimaPlugin, MimaKeys}
 
 scalaModuleSettings
 
 name                       := "scala-parser-combinators"
 
-version                    := "1.0.3-SNAPSHOT"
+version                    := "1.1.0-SNAPSHOT"
 
-scalaVersion               := "2.11.2"
+scalaVersion               := "2.11.4"
 
 snapshotScalaBinaryVersion := "2.11"
 
@@ -21,13 +20,3 @@ fork in Test := true
 libraryDependencies += "junit" % "junit" % "4.11" % "test"
 
 libraryDependencies += "com.novocode" % "junit-interface" % "0.10" % "test"
-
-MimaPlugin.mimaDefaultSettings
-
-MimaKeys.previousArtifact := Some(organization.value % s"${name.value}_2.11" % "1.0.2")
-
-// run mima during tests
-test in Test := {
-        MimaKeys.reportBinaryIssues.value
-        (test in Test).value
-}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.2")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.6")


### PR DESCRIPTION
Also moves to Scala 2.11.4.

Mima is disabled since `1.1.0` won't be binary compatible with `1.0.x`.
There will be a `1.0.x` branch for releases that should stay binary
compatible (like the version bundled in the Scala 2.11 distribution).
