### PR TITLE
Backport of #36

### DIFF
--- a/src/main/scala/scala/util/parsing/combinator/Parsers.scala
+++ b/src/main/scala/scala/util/parsing/combinator/Parsers.scala
@@ -884,7 +884,7 @@ trait Parsers {
         if (in1.atEnd)
           s
         else
-            lastNoSuccessVar.value filterNot { _.next.pos < in1.pos } getOrElse Failure("end of input expected", in1)
+          lastNoSuccessVar.value filterNot { _.next.pos < in1.pos } getOrElse Failure("end of input expected", in1)
         case ns => lastNoSuccessVar.value.getOrElse(ns)
       }
     }

--- a/src/main/scala/scala/util/parsing/combinator/RegexParsers.scala
+++ b/src/main/scala/scala/util/parsing/combinator/RegexParsers.scala
@@ -137,8 +137,19 @@ trait RegexParsers extends Parsers {
     }
   }
 
+  /**
+   * A parser generator delimiting whole phrases (i.e. programs).
+   *
+   * `phrase(p)` succeeds if `p` succeeds and no input is left over after `p`.
+   *
+   * @param p the parser that must consume all input for the resulting parser
+   *          to succeed.
+   *
+   * @return  a parser that has the same result as `p`, but that only succeeds
+   *          if `p` consumed all the input.
+   */
   override def phrase[T](p: Parser[T]): Parser[T] =
-    super.phrase(p <~ opt("""\z""".r))
+    super.phrase(p <~ "".r)
 
   /** Parse some prefix of reader `in` with parser `p`. */
   def parse[T](p: Parser[T], in: Reader[Char]): ParseResult[T] =


### PR DESCRIPTION
[backport] Fix misleading error message when using optional or repeatedly parser #34

(cherry picked from commit c0cfde11e5788b3b63e9ebbb4c0e16c84d1dd416)