### PR TITLE
Speed up line/column in OffsetPosition

### DIFF
--- a/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
+++ b/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
@@ -88,7 +88,7 @@ case class OffsetPosition(source: CharSequence, offset: Int) extends Position {
  *
  * @author Tomáš Janoušek
  */
-object OffsetPosition {
+object OffsetPosition extends scala.runtime.AbstractFunction2[CharSequence,Int,OffsetPosition] {
   private lazy val indexCacheTL =
     // not DynamicVariable as that would share the map from parent to child :-(
     new ThreadLocal[java.util.Map[CharSequence, Array[Int]]] {

--- a/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
+++ b/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
@@ -10,6 +10,8 @@ package scala
 package util.parsing.input
 
 import scala.collection.mutable.ArrayBuffer
+import java.lang.{CharSequence, ThreadLocal}
+import java.util.WeakHashMap
 
 /** `OffsetPosition` is a standard class for positions
  *   represented as offsets into a source ``document''.
@@ -19,7 +21,7 @@ import scala.collection.mutable.ArrayBuffer
  *
  * @author Martin Odersky
  */
-case class OffsetPosition(source: java.lang.CharSequence, offset: Int) extends Position {
+case class OffsetPosition(source: CharSequence, offset: Int) extends Position {
 
   /** An index that contains all line starts, including first line, and eof. */
   private lazy val index: Array[Int] = {
@@ -87,6 +89,11 @@ case class OffsetPosition(source: java.lang.CharSequence, offset: Int) extends P
  * @author Tomáš Janoušek
  */
 object OffsetPosition {
-  private lazy val indexCache = java.util.Collections.synchronizedMap(
-    new java.util.WeakHashMap[java.lang.CharSequence, Array[Int]])
+  private lazy val indexCacheTL =
+    // not DynamicVariable as that would share the map from parent to child :-(
+    new ThreadLocal[java.util.Map[CharSequence, Array[Int]]] {
+      override def initialValue = new WeakHashMap[CharSequence, Array[Int]]
+    }
+
+  private def indexCache = indexCacheTL.get
 }

--- a/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
+++ b/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
@@ -23,6 +23,16 @@ case class OffsetPosition(source: java.lang.CharSequence, offset: Int) extends P
 
   /** An index that contains all line starts, including first line, and eof. */
   private lazy val index: Array[Int] = {
+    Option(OffsetPosition.indexCache.get(source)) match {
+      case Some(index) => index
+      case None =>
+        val index = genIndex
+        OffsetPosition.indexCache.put(source, index)
+        index
+    }
+  }
+
+  private def genIndex: Array[Int] = {
     val lineStarts = new ArrayBuffer[Int]
     lineStarts += 0
     for (i <- 0 until source.length)
@@ -70,4 +80,13 @@ case class OffsetPosition(source: java.lang.CharSequence, offset: Int) extends P
       this.line < that.line ||
       this.line == that.line && this.column < that.column
   }
+}
+
+/** An object holding the index cache.
+ *
+ * @author Tomáš Janoušek
+ */
+object OffsetPosition {
+  private lazy val indexCache = java.util.Collections.synchronizedMap(
+    new java.util.WeakHashMap[java.lang.CharSequence, Array[Int]])
 }


### PR DESCRIPTION
Building the index again and again for every OffsetPosition instance makes
very little sense.  So this makes it build it only once for a given source.

I'm not sure if this is the best way to implement it and I'm afraid that a
global synchronized map may be a performance bottleneck once the number of
processors goes into the hundreds, but I know very little Scala/Java to do
this properly. :-(

Fixes
http://stackoverflow.com/questions/14707127/accessing-position-information-in-a-scala-combinatorparser-kills-performance