### PR TITLE
Prevent OffsetPosition.lineContents from grabbing a newline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: scala
 
+before_install:
+  - cat /etc/hosts # optionally check the content *before*
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - cat /etc/hosts # optionally check the content *after*
+
 env:
   global:
     - PUBLISH_JDK=openjdk6

--- a/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
+++ b/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
@@ -62,8 +62,14 @@ case class OffsetPosition(source: CharSequence, offset: Int) extends Position {
    *
    * @return the line at `offset` (not including a newline)
    */
-  def lineContents: String =
-    source.subSequence(index(line - 1), index(line)).toString
+  def lineContents: String = {
+    val endIndex = if (source.charAt(index(line) - 1) == '\n') {
+      index(line) -  1
+    } else {
+      index(line)
+    }
+    source.subSequence(index(line - 1), endIndex).toString
+  }
 
   /** Returns a string representation of the `Position`, of the form `line.column`. */
   override def toString = line+"."+column

--- a/src/test/scala/scala/util/parsing/combinator/gh56.scala
+++ b/src/test/scala/scala/util/parsing/combinator/gh56.scala
@@ -1,0 +1,57 @@
+package scala.util.parsing.combinator
+
+import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Test
+
+import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+
+/**
+  * Test for issue 56: https://github.com/scala/scala-parser-combinators/issues/56
+  *
+  * Makes sure that lineContents (and thus longString) in the Position trait doesn't
+  * include a newline
+  */
+class gh56 {
+  private object grammar extends StandardTokenParsers with PackratParsers {
+    lazy val term = (numericLit | stringLit | ident)+
+  }
+
+  @Test
+  def test1: Unit = {
+    import grammar._
+
+    val expr =
+      """/* an unclosed comment
+        |of multiple lines
+        |just to check longString/lineContents
+      """.stripMargin
+
+    val fail =
+      """[1.1] failure: identifier expected
+        |
+        |/* an unclosed comment
+        |^""".stripMargin
+
+    val parseResult = phrase(term)(new lexical.Scanner(expr))
+    assertTrue(parseResult.isInstanceOf[Failure])
+    assertEquals(fail, parseResult.toString)
+  }
+
+
+  @Test
+  def test2: Unit = {
+    import grammar._
+
+    val expr = "/* an unclosed comment without newline"
+
+    val fail =
+      """[1.1] failure: identifier expected
+        |
+        |/* an unclosed comment without newline
+        |^""".stripMargin
+
+    val parseResult = phrase(term)(new lexical.Scanner(expr))
+    assertTrue(parseResult.isInstanceOf[Failure])
+    assertEquals(fail, parseResult.toString)
+  }
+}


### PR DESCRIPTION
This is just a squashed resubmit of @toddobryan-amazon's work in #73.