### PR TITLE
Change apostrophe in error message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: scala
 before_install:
   - cat /etc/hosts # optionally check the content *before*
   - sudo hostname "$(hostname | cut -c1-63)"
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts > /tmp/hosts
+  - sudo mv /tmp/hosts /etc/hosts
   - cat /etc/hosts # optionally check the content *after*
 
 env:

--- a/src/main/scala/scala/util/parsing/combinator/Parsers.scala
+++ b/src/main/scala/scala/util/parsing/combinator/Parsers.scala
@@ -565,7 +565,7 @@ trait Parsers {
    *  @return a `tParser` that succeeds if `e` is the next available input.
    */
 
-  implicit def accept(e: Elem): Parser[Elem] = acceptIf(_ == e)("`"+e+"' expected but " + _ + " found")
+  implicit def accept(e: Elem): Parser[Elem] = acceptIf(_ == e)("'"+e+"' expected but " + _ + " found")
 
   /** A parser that matches only the given list of element `es`.
    *

--- a/src/test/scala/scala/util/parsing/combinator/PackratParsersTest.scala
+++ b/src/test/scala/scala/util/parsing/combinator/PackratParsersTest.scala
@@ -122,7 +122,7 @@ class PackratParsersTest {
       val failure = parseResult.asInstanceOf[Failure]
       assertEquals(expectedFailureMsg, failure.msg)
     }
-    assertFailure("``b'' expected but `c' found", "a a a a b b b c c c c")
+    assertFailure("'`b'' expected but `c' found", "a a a a b b b c c c c")
     assertFailure("end of input", "a a a a b b b b c c c")
   }
 


### PR DESCRIPTION
I'm not sure if this was intentionally left with `'` instead of "`" in the closing apostrophe, but just in case it was not I made the PR.
Scala CLA has been signed.