### PR TITLE
Redo how cross-version publishing works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
 
 env:
   global:
-    - PUBLISH_JDK=openjdk6
     # PGP_PASSPHRASE
     - secure: "SkBtn/6OjEldoikn0MFuyeLT/pau27kwKSDYTVQeJ4BKDzdWLwLE5Q3RukLGttIfNdhOvRoocpQSW9GkZfibTHmwrRnAokucfZCqTsKbwoOp1xIoOh5GrrVrB6gcP7WBTKinqFdBgSvLOrP7GviImz4ZuB9wq1r+mToGG4pDrXc="
     # SONA_USER
@@ -21,7 +20,6 @@ script: admin/build.sh
 
 jdk:
   - openjdk6
-  - openjdk7
   - oraclejdk8
 
 notifications:

--- a/admin/README.md
+++ b/admin/README.md
@@ -19,7 +19,7 @@ To configure tag driven releases from Travis CI.
      Edit `.travis.yml` as prompted.
   4. Edit `.travis.yml` to use `./admin/build.sh` as the build script,
      and edit that script to use the tasks required for this project.
-  5. Edit `.travis.yml` to select which JDK will be used for publishing.
+  5. Edit `build.sbt` to select which JDK will be used for publishing.
 
 It is important to add comments in .travis.yml to identify the name
 of each environment variable encoded in a `:secure` section.
@@ -30,7 +30,6 @@ form:
 	language: scala
 	env:
 	  global:
-	    - PUBLISH_JDK=openjdk6
 	    # PGP_PASSPHRASE
 	    - secure: "XXXXXX"
 	    # SONA_USER

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -7,7 +7,7 @@ set -e
 # git on travis does not fetch tags, but we have TRAVIS_TAG
 # headTag=$(git describe --exact-match ||:)
 
-if [ "$TRAVIS_JDK_VERSION" == "$PUBLISH_JDK" ] && [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)? ]]; then
+if [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)? ]]; then
   echo "Going to release from tag $TRAVIS_TAG!"
   myVer=$(echo $TRAVIS_TAG | sed -e s/^v//)
   publishVersion='set every version := "'$myVer'"'

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,23 @@
 scalaVersion in ThisBuild := crossScalaVersions.value.head
 
 crossScalaVersions in ThisBuild := {
+  val v211 = List("2.11.8")
+  val v212 = List("2.12.0-RC1")
+
   val javaVersion = System.getProperty("java.version")
-  val isJDK6Or7 =
-    javaVersion.startsWith("1.6.") || javaVersion.startsWith("1.7.")
-  if (isJDK6Or7)
-    Seq("2.11.8")
-  else
-    Seq("2.11.8", "2.12.0-RC1")
+  val isTravisPublishing = !util.Properties.envOrElse("TRAVIS_TAG", "").trim.isEmpty
+
+  if (isTravisPublishing) {
+    if (javaVersion.startsWith("1.6.")) v211
+    else if (javaVersion.startsWith("1.8.")) v212
+    else Nil
+  } else if (javaVersion.startsWith("1.6.") || javaVersion.startsWith("1.7.")) {
+    v211
+  } else if (javaVersion.startsWith("1.8.") || javaVersion.startsWith("9")) {
+    v211 ++ v212
+  } else {
+    sys.error(s"Unsupported java version: $javaVersion.")
+  }
 }
 
 lazy val `scala-parser-combinators` = crossProject.in(file(".")).


### PR DESCRIPTION
It used to be: only publish on JDK 6.

But now, 2.12.x requires Java 8. So we want the 2.11.x version to be
published on JDK 6, the 2.12.x version on JDK 8, and nothing on JDK 7.

Outside of publishing, we just run and test everything that can run on
the current JDK, like before.

This is inspired by Seth's commit at
scala/scala-xml@38fbbbeeff6bc97c4438e3e37041894c93538e46