### PR TITLE
Issue#89: making position a type member of parsers.scala.

### DIFF
--- a/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
@@ -76,14 +76,19 @@ import scala.util.DynamicVariable
  */
 trait Parsers {
   /** the type of input elements the provided parsers consume (When consuming
-   *  invidual characters, a parser is typically called a ''scanner'', which
+   *  individual characters, a parser is typically called a ''scanner'', which
    *  produces ''tokens'' that are consumed by what is normally called a ''parser''.
    *  Nonetheless, the same principles apply, regardless of the input type.) */
   type Elem
 
+  /** the type of position descriptors providing spatial information of the
+    * tokens within the input document.
+    */
+  type Pos <: Position
+
   /** The parser input is an abstract reader of input elements, i.e. the type
    *  of input the parsers in this component expect. */
-  type Input = Reader[Elem]
+  type Input = Reader[Elem, Pos]
 
   /** A base class for parser results. A result is either successful or not
    *  (failure may be fatal, i.e., an Error, or not, i.e., a Failure). On

--- a/shared/src/main/scala/scala/util/parsing/combinator/RegexParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/RegexParsers.scala
@@ -58,6 +58,8 @@ trait RegexParsers extends Parsers {
 
   type Elem = Char
 
+  type Pos = Position
+
   protected val whiteSpace = """\s+""".r
 
   def skipWhitespace = whiteSpace.toString.length > 0
@@ -152,7 +154,7 @@ trait RegexParsers extends Parsers {
     super.phrase(p <~ "".r)
 
   /** Parse some prefix of reader `in` with parser `p`. */
-  def parse[T](p: Parser[T], in: Reader[Char]): ParseResult[T] =
+  def parse[T](p: Parser[T], in: Reader[Char, Pos]): ParseResult[T] =
     p(in)
 
   /** Parse some prefix of character sequence `in` with parser `p`. */
@@ -164,7 +166,7 @@ trait RegexParsers extends Parsers {
     p(new PagedSeqReader(PagedSeq.fromReader(in)))
 
   /** Parse all of reader `in` with parser `p`. */
-  def parseAll[T](p: Parser[T], in: Reader[Char]): ParseResult[T] =
+  def parseAll[T](p: Parser[T], in: Reader[Char, Pos]): ParseResult[T] =
     parse(phrase(p), in)
 
   /** Parse all of reader `in` with parser `p`. */

--- a/shared/src/main/scala/scala/util/parsing/combinator/lexical/Scanners.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/lexical/Scanners.scala
@@ -22,6 +22,7 @@ import input._
  */
 trait Scanners extends Parsers {
   type Elem = Char
+  type Pos = Position
   type Token
 
   /** This token is produced by a scanner `Scanner` when scanning failed. */
@@ -39,7 +40,8 @@ trait Scanners extends Parsers {
    *
    *  @note ¹ `Scanner` is really a `Reader` of `Token`s
    */
-  class Scanner(in: Reader[Char]) extends Reader[Token] {
+  class Scanner(in: Reader[Char, Pos]) extends Reader[Token, Pos] {
+
     /** Convenience constructor (makes a character reader out of the given string) */
     def this(in: String) = this(new CharArrayReader(in.toCharArray()))
     private val (tok, rest1, rest2) = whitespace(in) match {
@@ -50,7 +52,7 @@ trait Scanners extends Parsers {
         }
       case ns: NoSuccess => (errorToken(ns.msg), ns.next, skip(ns.next))
     }
-    private def skip(in: Reader[Char]) = if (in.atEnd) in else in.rest
+    private def skip(in: Reader[Char, Pos]) = if (in.atEnd) in else in.rest
 
     override def source: java.lang.CharSequence = in.source
     override def offset: Int = in.offset

--- a/shared/src/main/scala/scala/util/parsing/combinator/syntactical/TokenParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/syntactical/TokenParsers.scala
@@ -12,6 +12,8 @@ package util.parsing
 package combinator
 package syntactical
 
+import input.Position
+
 /** This is the core component for token-based parsers.
  *
  *  @author Martin Odersky
@@ -29,6 +31,10 @@ trait TokenParsers extends Parsers {
 
   /** The input-type for these parsers*/
   type Elem = lexical.Token
+
+  /** The position-type for token parsers
+    */
+  type Pos = Position
 
 }
 

--- a/shared/src/main/scala/scala/util/parsing/input/CharSequenceReader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/CharSequenceReader.scala
@@ -27,7 +27,7 @@ object CharSequenceReader {
  * @author Martin Odersky
  */
 class CharSequenceReader(override val source: java.lang.CharSequence,
-                         override val offset: Int) extends Reader[Char] {
+                         override val offset: Int) extends Reader[Char, OffsetPosition] {
   import CharSequenceReader._
 
   /** Construct a `CharSequenceReader` with its first element at
@@ -51,7 +51,7 @@ class CharSequenceReader(override val source: java.lang.CharSequence,
 
   /** The position of the first element in the reader.
    */
-  def pos: Position = new OffsetPosition(source, offset)
+  def pos: OffsetPosition = new OffsetPosition(source, offset)
 
   /** true iff there are no more elements in this reader (except for trailing
    *  EofCh's)

--- a/shared/src/main/scala/scala/util/parsing/input/PagedSeqReader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/PagedSeqReader.scala
@@ -30,7 +30,7 @@ object PagedSeqReader {
  * @author Martin Odersky
  */
 class PagedSeqReader(seq: PagedSeq[Char],
-                     override val offset: Int) extends Reader[Char] { outer =>
+                     override val offset: Int) extends Reader[Char, Position] { outer =>
   import PagedSeqReader._
 
   override val source: java.lang.CharSequence = seq

--- a/shared/src/main/scala/scala/util/parsing/input/Reader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/Reader.scala
@@ -17,7 +17,7 @@ package util.parsing.input
  * @author Martin Odersky
  * @author Adriaan Moors
  */
-abstract class Reader[+T] {
+abstract class Reader[+T, +P <: Position] {
 
   /** If this is a reader over character sequences, the underlying char sequence.
    *  If not, throws a `NoSuchMethodError` exception.
@@ -39,12 +39,12 @@ abstract class Reader[+T] {
    * @return If `atEnd` is `true`, the result will be `this';
    *         otherwise, it's a `Reader` containing more elements.
    */
-  def rest: Reader[T]
+  def rest: Reader[T, P]
 
   /** Returns an abstract reader consisting of all elements except the first `n` elements.
    */
-  def drop(n: Int): Reader[T] = {
-    var r: Reader[T] = this
+  def drop(n: Int): Reader[T, P] = {
+    var r: Reader[T, P] = this
     var cnt = n
     while (cnt > 0) {
       r = r.rest; cnt -= 1
@@ -54,7 +54,7 @@ abstract class Reader[+T] {
 
   /** The position of the first element in the reader.
    */
-  def pos: Position
+  def pos: P
 
   /** `true` iff there are no more elements in this reader.
    */

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh45.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh45.scala
@@ -12,7 +12,7 @@ class gh45 {
 
   @Test
   def test4: Unit = {
-    def check(rd: Reader[Char]): Unit = {
+    def check(rd: Reader[Char, Position]): Unit = {
       val g = new grammar
       val p = g.phrase(g.script)
       val parseResult = p(new g.lexical.Scanner(rd))

--- a/shared/src/test/scala/scala/util/parsing/combinator/t0700.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t0700.scala
@@ -1,14 +1,14 @@
-import java.io.{File,StringReader}
+import java.io.{File, StringReader}
 
 import scala.util.parsing.combinator.Parsers
-import scala.util.parsing.input.{CharArrayReader, StreamReader}
-
+import scala.util.parsing.input.{CharArrayReader, Position, StreamReader}
 import org.junit.Test
 import org.junit.Assert.assertEquals
 
 class T0700 {
   class TestParsers extends Parsers {
     type Elem = Char
+    type Pos = Position
 
     def p: Parser[List[Int]] = rep(p1 | p2)
     def p1: Parser[Int] = 'a' ~ nl ~ 'b' ~ nl ^^^ 1

--- a/shared/src/test/scala/scala/util/parsing/combinator/t1100.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t1100.scala
@@ -1,23 +1,24 @@
 import scala.util.parsing.combinator.Parsers
-import scala.util.parsing.input.CharSequenceReader
-
-import java.io.{File,StringReader}
+import scala.util.parsing.input.{CharArrayReader, CharSequenceReader, Position, StreamReader}
+import java.io.{File, StringReader}
 
 import scala.util.parsing.combinator.Parsers
-import scala.util.parsing.input.{CharArrayReader, StreamReader}
-
 import org.junit.Test
 import org.junit.Assert.assertEquals
 
 class T1100 {
+
   class TestParsers extends Parsers {
     type Elem = Char
+    type Pos = Position
 
     def p: Parser[List[Char]] = rep1(p1)
+
     def p1: Parser[Char] = accept('a') | err("errors are propagated")
   }
 
-val expected = """[1.4] error: errors are propagated
+  val expected =
+    """[1.4] error: errors are propagated
 
 aaab
    ^"""

--- a/shared/src/test/scala/scala/util/parsing/combinator/t5514.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t5514.scala
@@ -7,8 +7,9 @@ import org.junit.Test
 import org.junit.Assert.assertEquals
 
 class T5514 extends Parsers {
+  type Pos = Position
   var readerCount = 0
-  class DemoReader(n: Int) extends Reader[String] {
+  class DemoReader(n: Int) extends Reader[String, Position] {
     def atEnd = n == 0
     def first = if (n >= 0) "s" + n else throw new IllegalArgumentException("No more input.")
     def rest = new DemoReader(n - 1)


### PR DESCRIPTION
At the moment, parsers.scala will use the base type Position, and leave
the specific position type to Readers. The downstream operation will
need to perform pattern matching to cast the position data into specific
type, e.g. OffsetPosition. This gets tedious if I already know that my
parser will only use one specific Position type.

Making position a type parameter will allow existing code to work, and
also allow downstream code to constraint position data type to be more
specific if needed.