### PR TITLE
Deprecate scala.util.parsing.json

### DIFF
--- a/shared/src/main/scala/scala/util/parsing/json/JSON.scala
+++ b/shared/src/main/scala/scala/util/parsing/json/JSON.scala
@@ -28,6 +28,7 @@ package util.parsing.json
  *
  * @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
+@deprecated("Use The Scala Library Index to find alternatives: https://index.scala-lang.org/", "1.0.6")
 object JSON extends Parser {
 
   /**

--- a/shared/src/main/scala/scala/util/parsing/json/Lexer.scala
+++ b/shared/src/main/scala/scala/util/parsing/json/Lexer.scala
@@ -18,6 +18,7 @@ import scala.util.parsing.input.CharArrayReader.EofCh
 /**
  *  @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
+@deprecated("Use The Scala Library Index to find alternatives: https://index.scala-lang.org/", "1.0.6")
 class Lexer extends StdLexical with ImplicitConversions {
 
   override def token: Parser[Token] =

--- a/shared/src/main/scala/scala/util/parsing/json/Parser.scala
+++ b/shared/src/main/scala/scala/util/parsing/json/Parser.scala
@@ -19,6 +19,7 @@ import scala.util.parsing.combinator.syntactical._
  *
  *  @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
+@deprecated("Use The Scala Library Index to find alternatives: https://index.scala-lang.org/", "1.0.6")
 sealed abstract class JSONType {
   /**
    * This version of toString allows you to provide your own value
@@ -40,6 +41,7 @@ sealed abstract class JSONType {
  *
  * @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
+@deprecated("Use The Scala Library Index to find alternatives: https://index.scala-lang.org/", "1.0.6")
 object JSONFormat {
   /**
    * This type defines a function that can be used to
@@ -91,6 +93,7 @@ object JSONFormat {
  *
  *  @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
+@deprecated("Use The Scala Library Index to find alternatives: https://index.scala-lang.org/", "1.0.6")
 case class JSONObject (obj : Map[String,Any]) extends JSONType {
   def toString (formatter : JSONFormat.ValueFormatter) =
     "{" + obj.map({ case (k,v) => formatter(k.toString) + " : " + formatter(v) }).mkString(", ") + "}"
@@ -100,6 +103,7 @@ case class JSONObject (obj : Map[String,Any]) extends JSONType {
  *  Represents a JSON Array (list).
  *  @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
+@deprecated("Use The Scala Library Index to find alternatives: https://index.scala-lang.org/", "1.0.6")
 case class JSONArray (list : List[Any]) extends JSONType {
   def toString (formatter : JSONFormat.ValueFormatter) =
     "[" + list.map(formatter).mkString(", ") + "]"
@@ -110,6 +114,7 @@ case class JSONArray (list : List[Any]) extends JSONType {
  *
  *  @author Derek Chen-Becker <"java"+@+"chen-becker"+"."+"org">
  */
+@deprecated("Use The Scala Library Index to find alternatives: https://index.scala-lang.org/", "1.0.6")
 class Parser extends StdTokenParsers with ImplicitConversions {
   // Fill in abstract defs
   type Tokens = Lexer

--- a/shared/src/main/scala/scala/util/parsing/json/package.scala
+++ b/shared/src/main/scala/scala/util/parsing/json/package.scala
@@ -1,0 +1,8 @@
+package scala.util.parsing
+
+/**
+  * This package was never intended for production use; it's really more of a code sample demonstrating how to use parser combinators.
+  *
+  * Use [[https://index.scala-lang.org/ The Scala Library Index]] to find alternative JSON parsing libraries.
+  */
+package object json {}


### PR DESCRIPTION
https://github.com/scala/scala-parser-combinators/issues/99

 - [x] Add json package with deprecation comments and link to The Scala Library Index
 - [x] Add deprecation to every top-level class/object in the package