### PR TITLE
remove lastNoSuccessVar

### DIFF
--- a/jvm/src/test/scala/scala/util/parsing/combinator/t9010.scala
+++ b/jvm/src/test/scala/scala/util/parsing/combinator/t9010.scala
@@ -7,42 +7,19 @@ class t9010 {
   @Test
   def test: Unit = {
     val p = new grammar
-    val lastNoSuccessVar = getLastNoSuccessVar(p)
     import p._
 
     val res1 = parse(x, "x")
     assert(res1.successful)
-    assert(lastNoSuccessVar.value == None)
 
     val res2 = parse(x, "y")
     assert(!res2.successful)
-    assert(lastNoSuccessVar.value == None)
 
     val res3 = parseAll(x, "x")
     assert(res3.successful)
-    assert(lastNoSuccessVar.value == None)
 
     val res4 = parseAll(x, "y")
     assert(!res4.successful)
-    assert(lastNoSuccessVar.value == None)
-  }
-
-  private def getLastNoSuccessVar(p: Parsers): DynamicVariable[Option[_]] = {
-    // use java reflection instead of scala (see below) because of
-    // https://issues.scala-lang.org/browse/SI-9306
-    val fn = "scala$util$parsing$combinator$Parsers$$lastNoSuccessVar"
-    val f = p.getClass.getDeclaredMethod(fn)
-    f.setAccessible(true)
-    f.invoke(p).asInstanceOf[DynamicVariable[Option[_]]]
-
-    /*
-    val ru = scala.reflect.runtime.universe
-    val mirror = ru.runtimeMirror(getClass.getClassLoader)
-    val lastNoSuccessVarField =
-      ru.typeOf[Parsers].decl(ru.TermName("lastNoSuccessVar")).asTerm.accessed.asTerm
-    mirror.reflect(p).reflectField(lastNoSuccessVarField).get.
-      asInstanceOf[DynamicVariable[Option[_]]]
-    */
   }
 
   private final class grammar extends RegexParsers {

--- a/shared/src/test/scala/scala/util/parsing/combinator/JavaTokenParsersTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/JavaTokenParsersTest.scala
@@ -47,6 +47,7 @@ class JavaTokenParsersTest {
     parseSuccess("with_")
     parseSuccess("_with")
 
+    parseFailure("", 1)
     parseFailure("3start", 1)
     parseFailure("-start", 1)
     parseFailure("with-s", 5)
@@ -72,8 +73,9 @@ class JavaTokenParsersTest {
     val parseResult1 = parseAll(p, "start start")
     parseResult1 match {
       case e @ Failure(message, next) =>
+        assertEquals(next.pos.line, 1)
         assertEquals(next.pos.column, 7)
-        assert(message.endsWith("string matching regex '(?i)AND' expected but 's' found"))
+        assert(message.endsWith(s"end of input expected"))
       case _ => sys.error(parseResult1.toString)
     }
 
@@ -97,7 +99,7 @@ class JavaTokenParsersTest {
       case Failure(message, next) =>
         assertEquals(next.pos.line, 1)
         assertEquals(next.pos.column, 1)
-        assert(message.endsWith(s"identifier expected but '-' found"))
+        assert(message.endsWith(s"end of input expected"))
       case _ => sys.error(parseResult.toString)
     }
 


### PR DESCRIPTION
`lastNoSuccessVar` is introducing a non referentially transparent, hard to debug source
of errors where parsing Failures are remembered and, even if they are covered by subsequent
combinators, such as `|`, still replaces correct Failures at the end of phrase parsing with them.

This is confusing from two perspectives:
 - how is that error that should have been covered not fixed by the `|`?
 - what is the real parsing error that I should focus to fix in my input?

a small example:

let's assume we are creating a parser to parse `(IF condition THEN 1 END)*`.
let `condition` be `TRUE|FALSE`.

when given input `IF FALSE THEN 1 IF TRUE THEN 1 END` (note the missing `END`), the parser would have returned:
  `TRUE expected, FALSE given`.

Which is obviously not correct, as FALSE is a valid option described in the parser, and the correct error is that the `END` token is missing.


This PR replaces issue #107 .