### PR TITLE
Allow building an existing tag against a new Scala version

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -1,7 +1,5 @@
 ## Tag Driven Releasing
 
-Copied from https://github.com/scala/scala-java8-compat/commit/4a6cfc97cd95227b86650410e1b632e5ff79335b.
-
 ### Background Reading
 
   - http://docs.travis-ci.com/user/environment-variables/
@@ -14,47 +12,61 @@ To configure tag driven releases from Travis CI.
 
   1. Generate a key pair for this repository with `./admin/genKeyPair.sh`.
      Edit `.travis.yml` and `admin/build.sh` as prompted.
-  2. Publish the public key to https://pgp.mit.edu
-  3. Store other secrets as encrypted environment variables with `admin/encryptEnvVars.sh`.
+  1. Publish the public key to https://pgp.mit.edu
+  1. Store other secrets as encrypted environment variables with `admin/encryptEnvVars.sh`.
      Edit `.travis.yml` as prompted.
-  4. Edit `.travis.yml` to use `./admin/build.sh` as the build script,
+  1. Edit `.travis.yml` to use `./admin/build.sh` as the build script,
      and edit that script to use the tasks required for this project.
-  5. Edit `build.sbt` to select which JDK will be used for publishing.
+  1. Edit `build.sbt`'s `scalaVersionsByJvm in ThisBuild` to select Scala and JVM version
+     combinations that will be used for publishing.
 
-It is important to add comments in .travis.yml to identify the name
+It is important to add comments in `.travis.yml` to identify the name
 of each environment variable encoded in a `:secure` section.
 
-After all of these steps, your .travis.yml should contain config of the
-form:
+After these steps, your `.travis.yml` should contain config of the form:
 
-	language: scala
-	env:
-	  global:
-	    # PGP_PASSPHRASE
-	    - secure: "XXXXXX"
-	    # SONA_USER
-	    - secure: "XXXXXX"
-	    # SONA_PASS
-	    - secure: "XXXXXX"
-	script: admin/build.sh
+```
+language: scala
+
+env:
+  global:
+    # PGP_PASSPHRASE
+    - secure: "XXXXXX"
+    # SONA_USER
+    - secure: "XXXXXX"
+    # SONA_PASS
+    - secure: "XXXXXX"
+
+script: admin/build.sh
+
+jdk:
+  - openjdk6
+  - oraclejdk8
+
+notifications:
+  email:
+    - a@b.com
+```
 
 If Sonatype credentials change in the future, step 3 can be repeated
 without generating a new key.
 
-Be sure to use SBT 0.13.7 or higher to avoid [#1430](https://github.com/sbt/sbt/issues/1430)!
-
 ### Testing
 
-  1. Follow the release process below to create a dummy release (e.g. 0.1.0-TEST1).
+  1. Follow the release process below to create a dummy release (e.g., `v0.1.0-TEST1`).
      Confirm that the release was staged to Sonatype but do not release it to Maven
      central. Instead, drop the staging repository.
 
 ### Performing a release
 
-  1. Create a GitHub "Release" (with a corresponding tag) via the GitHub
+  1. Create a GitHub "Release" with a corresponding tag (e.g., `v0.1.1`) via the GitHub
      web interface.
-  2. Travis CI will schedule a build for this release. Review the build logs.
-  3. Log into https://oss.sonatype.org/ and identify the staging repository.
-  4. Sanity check its contents
-  5. Release staging repository to Maven and send out release announcement.
-
+  1. The release will be published using the Scala and JVM version combinations specified
+     in `scalaVersionsByJvm` in `build.sbt`.
+     - If you need to release against a different Scala version, include the Scala version
+       and the JVM version to use in the tag name, separated by `#`s (e.g., `v0.1.1#2.13.0-M1#8`).
+       Note that the JVM version needs to be listed in `.travis.yml` for the build to run.
+  1. Travis CI will schedule a build for this release. Review the build logs.
+  1. Log into https://oss.sonatype.org/ and identify the staging repository.
+  1. Sanity check its contents.
+  1. Release staging repository to Maven and send out release announcement.

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -2,15 +2,43 @@
 
 set -e
 
-# prep environment for publish to sonatype staging if the HEAD commit is tagged
+# Builds of tagged revisions are published to sonatype staging.
 
-# git on travis does not fetch tags, but we have TRAVIS_TAG
-# headTag=$(git describe --exact-match ||:)
+# Travis runs a build on new revisions and on new tags, so a tagged revision is built twice.
+# Builds for a tag have TRAVIS_TAG defined, which we use for identifying tagged builds.
+# Checking the local git clone would not work because git on travis does not fetch tags.
 
-if [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)? ]]; then
-  echo "Going to release from tag $TRAVIS_TAG!"
-  myVer=$(echo $TRAVIS_TAG | sed -e s/^v//)
-  publishVersion='set every version := "'$myVer'"'
+# The version number to be published is extracted from the tag, e.g., v1.2.3 publishes
+# version 1.2.3 using all Scala versions in build.sbt's `crossScalaVersions`.
+
+# When a new, binary incompatible Scala version becomes available, a previously released version
+# can be released using that new Scala version by creating a new tag containing the Scala and the
+# JVM version after hashes, e.g., v1.2.3#2.13.0-M1#8. The JVM version needs to be listed in
+# `.travis.yml`, otherwise the required build doesn't run.
+
+verPat="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?"
+tagPat="^v$verPat(#$verPat#[0-9]+)?$"
+
+if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
+  currentJvmVer=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/^1\.//' | sed 's/[^0-9].*//')
+
+  tagVer=$(echo $TRAVIS_TAG | sed s/#.*// | sed s/^v//)
+  publishVersion='set every version := "'$tagVer'"'
+
+  scalaAndJvmVer=$(echo $TRAVIS_TAG | sed s/[^#]*// | sed s/^#//)
+  if [ "$scalaAndJvmVer" != "" ]; then
+    scalaVer=$(echo $scalaAndJvmVer | sed s/#.*//)
+    jvmVer=$(echo $scalaAndJvmVer | sed s/[^#]*// | sed s/^#//)
+    if [ "$jvmVer" != "$currentJvmVer" ]; then
+      echo "Not publishing $TRAVIS_TAG on Java version $currentJvmVer."
+      exit 0
+    fi
+    publishScalaVersion='set every ScalaModulePlugin.scalaVersionsByJvm := Map('$jvmVer' -> List("'$scalaVer'" -> true))'
+    echo "Releasing $tagVer using Scala $scalaVer on Java version $jvmVer."
+  else
+    echo "Releasing $tagVer on Java version $currentJvmVer according to 'scalaVersionsByJvm' in build.sbt."
+  fi
+
   extraTarget="+publish-signed"
   cat admin/gpg.sbt >> project/plugins.sbt
   cp admin/publish-settings.sbt .
@@ -22,4 +50,4 @@ if [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)? ]]; then
   openssl aes-256-cbc -K $K -iv $IV -in admin/secring.asc.enc -out admin/secring.asc -d
 fi
 
-sbt "$publishVersion" clean update +test +publishLocal $extraTarget
+sbt "$publishVersion" "$publishScalaVersion" clean update +test +publishLocal $extraTarget

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,15 @@
 import ScalaModulePlugin._
 
 scalaVersionsByJvm in ThisBuild := {
-  val v212 = "2.12.2"
   val v211 = "2.11.11"
+  val v212 = "2.12.2"
+  val v213 = "2.13.0-M1"
 
   Map(
     6 -> List(v211 -> true),
     7 -> List(v211 -> false),
-    8 -> List(v212 -> true, v211 -> false),
-    9 -> List(v212 -> false, v211 -> false)
+    8 -> List(v212 -> true, v213 -> true, v211 -> false),
+    9 -> List(v212 -> false, v213 -> false, v211 -> false)
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,23 +1,15 @@
-scalaVersion in ThisBuild := crossScalaVersions.value.head
+import ScalaModulePlugin._
 
-crossScalaVersions in ThisBuild := {
-  val v211 = List("2.11.8")
-  val v212 = List("2.12.1")
+scalaVersionsByJvm in ThisBuild := {
+  val v212 = "2.12.2"
+  val v211 = "2.11.11"
 
-  val javaVersion = System.getProperty("java.version")
-  val isTravisPublishing = !util.Properties.envOrElse("TRAVIS_TAG", "").trim.isEmpty
-
-  if (isTravisPublishing) {
-    if (javaVersion.startsWith("1.6.")) v211
-    else if (javaVersion.startsWith("1.8.")) v212
-    else Nil
-  } else if (javaVersion.startsWith("1.6.") || javaVersion.startsWith("1.7.")) {
-    v211
-  } else if (javaVersion.startsWith("1.8.") || javaVersion.startsWith("9")) {
-    v211 ++ v212
-  } else {
-    sys.error(s"Unsupported java version: $javaVersion.")
-  }
+  Map(
+    6 -> List(v211 -> true),
+    7 -> List(v211 -> false),
+    8 -> List(v212 -> true, v211 -> false),
+    9 -> List(v212 -> false, v211 -> false)
+  )
 }
 
 lazy val `scala-parser-combinators` = crossProject.in(file(".")).
@@ -44,22 +36,14 @@ lazy val `scala-parser-combinators` = crossProject.in(file(".")).
     name := "scala-parser-combinators"
   ).
   jsSettings(
-    name := "scala-parser-combinators-js",
-    scalaJSUseRhino := true
+    name := "scala-parser-combinators-js"
   ).
   settings(
     moduleName         := "scala-parser-combinators",
     version            := "1.0.6-SNAPSHOT"
   ).
   jvmSettings(
-    // important!! must come here (why?)
-    scalaModuleOsgiSettings: _*
-  ).
-  jvmSettings(
-    OsgiKeys.exportPackage := Seq(s"scala.util.parsing.*;version=${version.value}"),
-
-    // needed to fix classloader issues (see scala-xml#20)
-    fork in Test := true
+    OsgiKeys.exportPackage := Seq(s"scala.util.parsing.*;version=${version.value}")
   ).
   jsSettings(
     // Scala.js cannot run forked tests

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.4")
+addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.8")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.16")


### PR DESCRIPTION
For tags of the form `v1.2.3-suffix#2.13.0-M1`, the build script
releases version `1.2.3-suffix` using Scala version `2.13.0-M1`.

This allows building an existing tag against a new Scala version.