### PR TITLE
Upgrade scala-module-plugin, use scalaVersionsByJvm

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -19,7 +19,8 @@ To configure tag driven releases from Travis CI.
      Edit `.travis.yml` as prompted.
   4. Edit `.travis.yml` to use `./admin/build.sh` as the build script,
      and edit that script to use the tasks required for this project.
-  5. Edit `build.sbt` to select which JDK will be used for publishing.
+  5. Edit `build.sbt`'s `scalaVersionsByJvm` to select which Scala and JDK will
+     be used for publishing.
 
 It is important to add comments in .travis.yml to identify the name
 of each environment variable encoded in a `:secure` section.
@@ -37,11 +38,12 @@ form:
 	    # SONA_PASS
 	    - secure: "XXXXXX"
 	script: admin/build.sh
+        jdk:
+            - openjdk6
+            - oraclejdk8
 
 If Sonatype credentials change in the future, step 3 can be repeated
 without generating a new key.
-
-Be sure to use SBT 0.13.7 or higher to avoid [#1430](https://github.com/sbt/sbt/issues/1430)!
 
 ### Testing
 
@@ -53,8 +55,13 @@ Be sure to use SBT 0.13.7 or higher to avoid [#1430](https://github.com/sbt/sbt/
 
   1. Create a GitHub "Release" (with a corresponding tag) via the GitHub
      web interface.
-  2. Travis CI will schedule a build for this release. Review the build logs.
-  3. Log into https://oss.sonatype.org/ and identify the staging repository.
-  4. Sanity check its contents
-  5. Release staging repository to Maven and send out release announcement.
+  2. The release will be published using the Scala and JVM version combinations specified
+     in `scalaVersionsByJvm` in `build.sbt`.
+     - If you need to release against a different Scala version, include the Scala version
+       and the JVM version to use in the tag name, separated by `#`s (e.g., `v0.1.1#2.13.0-M1#8`).
+       Note that the JVM version needs to be listed in `.travis.yml` for the build to run.
+  3. Travis CI will schedule a build for this release. Review the build logs.
+  4. Log into https://oss.sonatype.org/ and identify the staging repository.
+  5. Sanity check its contents
+  6. Release staging repository to Maven and send out release announcement.
 

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -2,24 +2,52 @@
 
 set -e
 
-# prep environment for publish to sonatype staging if the HEAD commit is tagged
+# Builds of tagged revisions are published to sonatype staging.
 
-# git on travis does not fetch tags, but we have TRAVIS_TAG
-# headTag=$(git describe --exact-match ||:)
+# Travis runs a build on new revisions and on new tags, so a tagged revision is built twice.
+# Builds for a tag have TRAVIS_TAG defined, which we use for identifying tagged builds.
+# Checking the local git clone would not work because git on travis does not fetch tags.
 
-if [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)? ]]; then
-  echo "Going to release from tag $TRAVIS_TAG!"
-  myVer=$(echo $TRAVIS_TAG | sed -e s/^v//)
-  publishVersion='set every version := "'$myVer'"'
-  extraTarget="+publish-signed"
-  cat admin/gpg.sbt >> project/plugins.sbt
-  cp admin/publish-settings.sbt .
+# The version number to be published is extracted from the tag, e.g., v1.2.3 publishes
+# version 1.2.3 using all Scala versions in build.sbt's `crossScalaVersions`.
 
-  # Copied from the output of genKeyPair.sh
-  K=$encrypted_5e972ec514e2_key
-  IV=$encrypted_5e972ec514e2_iv
+# When a new, binary incompatible Scala version becomes available, a previously released version
+# can be released using that new Scala version by creating a new tag containing the Scala and the
+# JVM version after hashes, e.g., v1.2.3#2.13.0-M1#8. The JVM version needs to be listed in
+# `.travis.yml`, otherwise the required build doesn't run.
 
-  openssl aes-256-cbc -K $K -iv $IV -in admin/secring.asc.enc -out admin/secring.asc -d
+verPat="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?"
+tagPat="^v$verPat(#$verPat#[0-9]+)?$"
+
+if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
+	currentJvmVer=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/^1\.//' | sed 's/[^0-9].*//')
+
+	tagVer=$(echo $TRAVIS_TAG | sed s/#.*// | sed s/^v//)
+	publishVersion='set every version := "'$tagVer'"'
+	scalaAndJvmVer=$(echo $TRAVIS_TAG | sed s/[^#]*// | sed s/^#//)
+	if [ "$scalaAndJvmVer" != "" ]; then
+		scalaVer=$(echo $scalaAndJvmVer | sed s/#.*//)
+		jvmVer=$(echo $scalaAndJvmVer | sed s/[^#]*// | sed s/^#//)
+		if [ "$jvmVer" != "$currentJvmVer" ]; then
+			echo "Not publishing $TRAVIS_TAG on Java version $currentJvmVer."
+			exit 0
+		fi
+		publishScalaVersion='set every scalaVersionsByJvm := Map('$jvmVer' -> List("'$scalaVer'" -> true))'
+		echo "Releasing $tagVer using Scala $scalaVer on Java version $jvmVer."
+	else
+		echo "Releasing $tagVer on Java version $currentJvmVer according to 'scalaVersionsByJvm' in build.sbt."
+	fi
+
+
+	extraTarget="+publish-signed"
+	cat admin/gpg.sbt >> project/plugins.sbt
+	cp admin/publish-settings.sbt .
+
+	# Copied from the output of genKeyPair.sh
+	K=$encrypted_5e972ec514e2_key
+	IV=$encrypted_5e972ec514e2_iv
+
+	openssl aes-256-cbc -K $K -iv $IV -in admin/secring.asc.enc -out admin/secring.asc -d
 fi
 
-sbt "$publishVersion" clean update +test +publishLocal $extraTarget
+sbt "$publishVersion" "$publishScalaVersion" clean update +test +publishLocal $extraTarget

--- a/build.sbt
+++ b/build.sbt
@@ -1,29 +1,24 @@
-scalaVersion in ThisBuild := crossScalaVersions.value.head
-
-crossScalaVersions in ThisBuild := {
-  val v211 = List("2.11.8")
-  val v212 = List("2.12.1")
-
-  val javaVersion = System.getProperty("java.version")
-  val isTravisPublishing = !util.Properties.envOrElse("TRAVIS_TAG", "").trim.isEmpty
-
-  if (isTravisPublishing) {
-    if (javaVersion.startsWith("1.6.")) v211
-    else if (javaVersion.startsWith("1.8.")) v212
-    else Nil
-  } else if (javaVersion.startsWith("1.6.") || javaVersion.startsWith("1.7.")) {
-    v211
-  } else if (javaVersion.startsWith("1.8.") || javaVersion.startsWith("9")) {
-    v211 ++ v212
-  } else {
-    sys.error(s"Unsupported java version: $javaVersion.")
-  }
-}
+lazy val root = project.in(file("."))
+  .aggregate(`scala-parser-combinatorsJVM`, `scala-parser-combinatorsJS`)
+  .settings(publish := {}, publishLocal := {},
+    crossScalaVersions := (crossScalaVersions in LocalProject("scala-parser-combinatorsJVM")).value,
+    scalaVersion := crossScalaVersions.value.head)
 
 lazy val `scala-parser-combinators` = crossProject.in(file(".")).
   settings(scalaModuleSettings: _*).
   settings(
     name := "scala-parser-combinators-root",
+    scalaVersionsByJvm := {
+      val v212 = "2.12.2"
+      val v211 = "2.11.11"
+
+      Map(
+        6 -> List(v211 -> true),
+        7 -> List(v211 -> false),
+        8 -> List(v212 -> true, v211 -> false),
+        9 -> List(v212 -> false, v211 -> false)
+      )
+    },
     apiMappings += (scalaInstance.value.libraryJar ->
         url(s"https://www.scala-lang.org/api/${scalaVersion.value}/")),
     scalacOptions in (Compile, doc) ++= Seq(
@@ -44,8 +39,7 @@ lazy val `scala-parser-combinators` = crossProject.in(file(".")).
     name := "scala-parser-combinators"
   ).
   jsSettings(
-    name := "scala-parser-combinators-js",
-    scalaJSUseRhino := true
+    name := "scala-parser-combinators-js"
   ).
   settings(
     moduleName         := "scala-parser-combinators",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.4")
+addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.6")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")


### PR DESCRIPTION
 - Upgrade to:
   - scala 2.11.11, 2.12.2
   - latest scala-module-plugin, with `scalaVersionByJvm`
   - latest sbt
   - latest scala-js
 - Add support for republishing an old version against a new Scala version (from scala/scala-swing#60)

I'll add support for 2.13.0-M1 as soon as the scala-js plugin becomes available.