### PR TITLE
fixing js version publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,8 @@ lazy val `scala-parser-combinators` = crossProject.in(file(".")).
       "Scala Parser Combinators",
       "-doc-version",
       version.value
-    )
+    ),
+    OsgiKeys.exportPackage := Seq(s"scala.util.parsing.*;version=${version.value}")
   ).
   jvmSettings(
     // Mima uses the name of the jvm project in the artifactId
@@ -46,9 +47,6 @@ lazy val `scala-parser-combinators` = crossProject.in(file(".")).
   settings(
     moduleName         := "scala-parser-combinators",
     version            := "1.0.7-SNAPSHOT"
-  ).
-  jvmSettings(
-    OsgiKeys.exportPackage := Seq(s"scala.util.parsing.*;version=${version.value}")
   ).
   jsSettings(
     // Scala.js cannot run forked tests


### PR DESCRIPTION
Currently, scala-js version of scala-parser-combinators contains zero classes because no packages are exported for js-version. This fix ensures that OsgiKeys.exportPackage is set up for jvm and js versions.

Testing: `publishLocal` before fix, check that jvm version is OK, but js version has zero classes. `publishLocal` after fix, check that both versions are OK.