### PR TITLE
Update to sbt-scala-module 1.0.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,10 +19,15 @@ lazy val root = project.in(file("."))
 
 lazy val `scala-parser-combinators` = crossProject.in(file(".")).
   settings(scalaModuleSettings: _*).
+  jvmSettings(scalaModuleSettingsJVM).
   settings(
-    name := "scala-parser-combinators-root",
+    repoName := "scala-parser-combinators",
+    version := "1.0.7-SNAPSHOT",
+    mimaPreviousVersion := Some("1.0.5"),
+
     apiMappings += (scalaInstance.value.libraryJar ->
         url(s"https://www.scala-lang.org/api/${scalaVersion.value}/")),
+
     scalacOptions in (Compile, doc) ++= Seq(
       "-diagrams",
       "-doc-source-url",
@@ -36,32 +41,15 @@ lazy val `scala-parser-combinators` = crossProject.in(file(".")).
     )
   ).
   jvmSettings(
-    // Mima uses the name of the jvm project in the artifactId
-    // when resolving previous versions (so no "-jvm" project)
-    name := "scala-parser-combinators"
-  ).
-  jsSettings(
-    name := "scala-parser-combinators-js"
-  ).
-  settings(
-    moduleName         := "scala-parser-combinators",
-    version            := "1.0.7-SNAPSHOT"
-  ).
-  jvmSettings(
-    OsgiKeys.exportPackage := Seq(s"scala.util.parsing.*;version=${version.value}")
+    OsgiKeys.exportPackage := Seq(s"scala.util.parsing.*;version=${version.value}"),
+    libraryDependencies += "junit" % "junit" % "4.12" % "test",
+    libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
   ).
   jsSettings(
     // Scala.js cannot run forked tests
     fork in Test := false
   ).
-  jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin)).
-  jvmSettings(
-    libraryDependencies += "junit" % "junit" % "4.12" % "test",
-    libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
-  ).
-  jvmSettings(
-    mimaPreviousVersion := Some("1.0.4")
-  )
+  jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
 
 lazy val `scala-parser-combinatorsJVM` = `scala-parser-combinators`.jvm
 lazy val `scala-parser-combinatorsJS` = `scala-parser-combinators`.js

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.8")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.12")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.16")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")


### PR DESCRIPTION
Add osgi settings only to the `JVM` project. In the JS project they
caused the resulting jar to be empty.

Fixes #119

Adds MiMa checking to the JS jar.

Minor cleanups in the build definition.