### PR TITLE
#128: prevent OutOfBoundsException on trailing newline

### DIFF
--- a/shared/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
@@ -63,12 +63,14 @@ case class OffsetPosition(source: CharSequence, offset: Int) extends Position {
    * @return the line at `offset` (not including a newline)
    */
   def lineContents: String = {
-    val endIndex = if (source.charAt(index(line) - 1) == '\n') {
-      index(line) -  1
+    val lineStart = index(line - 1)
+    val lineEnd = index(line)
+    val endIndex = if ( lineStart < lineEnd && source.charAt(lineEnd - 1) == '\n') {
+      lineEnd - 1
     } else {
-      index(line)
+      lineEnd
     }
-    source.subSequence(index(line - 1), endIndex).toString
+    source.subSequence(lineStart, endIndex).toString
   }
 
   /** Returns a string representation of the `Position`, of the form `line.column`. */

--- a/shared/src/test/scala/scala/util/parsing/input/OffsetPositionTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/input/OffsetPositionTest.scala
@@ -1,0 +1,18 @@
+package scala.util.parsing.input
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class OffsetPositionTest {
+  @Test
+  def printLineContentsWithTrailingNewLine: Unit = {
+    val op = new OffsetPosition("\n", 1)
+    assertEquals(op.lineContents, "")
+  }
+
+  @Test
+  def printLineContentsWithEmptySource: Unit = {
+    val op = new OffsetPosition("", 0)
+    assertEquals(op.lineContents, "")
+  }
+}


### PR DESCRIPTION
This prevents the exception in issue #128. I also added a unit test.