### PR TITLE
Travis makes us work harder now to actually get OpenJDK 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,11 @@ env:
 
 script: admin/build.sh
 
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+
 jdk:
   - openjdk6
   - oraclejdk8


### PR DESCRIPTION
as per:
https://github.com/travis-ci/travis-ci/issues/8199#issuecomment-327246053

an example Travis run where we were asking for 6 but getting 8: https://travis-ci.org/scala/scala-parser-combinators/jobs/286076608