### PR TITLE
Fix js/native support & bump sbt and plugins versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,19 +44,16 @@ lazy val `scala-parser-combinators` = crossProject(JSPlatform, JVMPlatform, Nati
   jvmSettings(
     // Mima uses the name of the jvm project in the artifactId
     // when resolving previous versions (so no "-jvm" project)
-    name := "scala-parser-combinators",
     OsgiKeys.exportPackage := Seq(s"scala.util.parsing.*;version=${version.value}"),
     libraryDependencies += "junit" % "junit" % "4.12" % "test",
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
   ).
   jsSettings(
-    name := "scala-parser-combinators-js",
     // Scala.js cannot run forked tests
     fork in Test := false
   ).
   jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin)).
   nativeSettings(
-    name := "scala-parser-combinators-native",
     scalaVersion := "2.11.11",
     skip in compile := System.getProperty("java.version").startsWith("1.6"),
     test := {},

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.12")
 
-addSbtPlugin("org.scala-js"     % "sbt-scalajs"              % "0.6.18")
-addSbtPlugin("org.scala-native" % "sbt-crossproject"         % "0.2.0")
-addSbtPlugin("org.scala-native" % "sbt-scalajs-crossproject" % "0.2.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native"         % "0.3.1")
+addSbtPlugin("org.scala-js"     % "sbt-scalajs"              % "0.6.21")
+addSbtPlugin("org.scala-native" % "sbt-crossproject"         % "0.2.2")
+addSbtPlugin("org.scala-native" % "sbt-scalajs-crossproject" % "0.2.2")
+addSbtPlugin("org.scala-native" % "sbt-scala-native"         % "0.3.3")


### PR DESCRIPTION
Naming the js/native projects by hand changed the produced artifactIds
(`scala-parser-combinators-js_sjs0.6_2.12`), and that breaks dependency resolution.

And then we can release 1.0.7! :tada: