### PR TITLE
Get everything ready to release 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,18 @@ env:
 
 script: admin/build.sh
 
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+
 jdk:
   - openjdk6
   - oraclejdk8
 
 notifications:
   email:
-    - adriaan.moors@typesafe.com
+    - adriaan.moors@lightbend.com
     - antoine@gourlay.fr
 
 before_cache:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
-Copyright (c) 2002-2013 EPFL
-Copyright (c) 2011-2013 Typesafe, Inc.
+Copyright (c) 2002-2018 EPFL
+Copyright (c) 2011-2018 Lightbend, Inc.
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-scala-parser-combinators [<img src="https://img.shields.io/travis/scala/scala-parser-combinators.svg"/>](https://travis-ci.org/scala/scala-parser-combinators) [<img src="https://img.shields.io/maven-central/v/org.scala-lang.modules/scala-parser-combinators_2.11.svg?label=latest%20release%20for%202.11"/>](http://search.maven.org/#search%7Cga%7C1%7Cg%3Aorg.scala-lang.modules%20a%3Ascala-parser-combinators_2.11) [<img src="https://img.shields.io/maven-central/v/org.scala-lang.modules/scala-parser-combinators_2.12*.svg?label=latest%20release%20for%202.12"/>](http://search.maven.org/#search%7Cga%7C1%7Cg%3Aorg.scala-lang.modules%20a%3Ascala-parser-combinators_2.12*) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scala/scala-parser-combinators)
+scala-parser-combinators [<img src="https://img.shields.io/travis/scala/scala-parser-combinators.svg"/>](https://travis-ci.org/scala/scala-parser-combinators) [<img src="https://img.shields.io/maven-central/v/org.scala-lang.modules/scala-parser-combinators_2.11.svg?label=latest%20release%20for%202.11"/>](http://search.maven.org/#search%7Cga%7C1%7Cg%3Aorg.scala-lang.modules%20a%3Ascala-parser-combinators_2.11) [<img src="https://img.shields.io/maven-central/v/org.scala-lang.modules/scala-parser-combinators_2.12.svg?label=latest%20release%20for%202.12"/>](http://search.maven.org/#search%7Cga%7C1%7Cg%3Aorg.scala-lang.modules%20a%3Ascala-parser-combinators_2.12) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scala/scala-parser-combinators)
 ========================
 
 ### Scala Standard Parser Combinator Library
@@ -18,7 +18,7 @@ As of Scala 2.11, this library is a separate jar that can be omitted from Scala 
 To depend on scala-parser-combinators in SBT, add something like this to your build.sbt:
 
 ```
-libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6"
+libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.7"
 ```
 
 (Assuming you're using a `scalaVersion` for which a scala-parser-combinators is published. The first 2.11 milestone for which this is true is 2.11.0-M4.)
@@ -60,7 +60,7 @@ For a detailed unpacking of this example see
 Scala-parser-combinators directly supports scala-js 0.6+, starting with v1.0.5:
 
 ```
-libraryDependencies += "org.scala-lang.modules" %%% "scala-parser-combinators" % "1.0.6"
+libraryDependencies += "org.scala-lang.modules" %%% "scala-parser-combinators" % "1.0.7"
 ```
 
 ## Contributing

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 import ScalaModulePlugin._
 
 scalaVersionsByJvm in ThisBuild := {
-  val v211 = "2.11.11"
-  val v212 = "2.12.2"
-  val v213 = "2.13.0-M1"
+  val v211 = "2.11.12"
+  val v212 = "2.12.4"
+  val v213 = "2.13.0-M2"
 
   Map(
     6 -> List(v211 -> true),
@@ -19,10 +19,15 @@ lazy val root = project.in(file("."))
 
 lazy val `scala-parser-combinators` = crossProject.in(file(".")).
   settings(scalaModuleSettings: _*).
+  jvmSettings(scalaModuleSettingsJVM).
   settings(
-    name := "scala-parser-combinators-root",
+    name := "scala-parser-combinators",
+    version := "1.1.0-SNAPSHOT",
+    mimaPreviousVersion := None,
+
     apiMappings += (scalaInstance.value.libraryJar ->
         url(s"https://www.scala-lang.org/api/${scalaVersion.value}/")),
+
     scalacOptions in (Compile, doc) ++= Seq(
       "-diagrams",
       "-doc-source-url",
@@ -36,32 +41,15 @@ lazy val `scala-parser-combinators` = crossProject.in(file(".")).
     )
   ).
   jvmSettings(
-    // Mima uses the name of the jvm project in the artifactId
-    // when resolving previous versions (so no "-jvm" project)
-    name := "scala-parser-combinators"
-  ).
-  jsSettings(
-    name := "scala-parser-combinators-js"
-  ).
-  settings(
-    moduleName         := "scala-parser-combinators",
-    version            := "1.1.0-SNAPSHOT"
-  ).
-  jvmSettings(
-    OsgiKeys.exportPackage := Seq(s"scala.util.parsing.*;version=${version.value}")
+    OsgiKeys.exportPackage := Seq(s"scala.util.parsing.*;version=${version.value}"),
+    libraryDependencies += "junit" % "junit" % "4.12" % "test",
+    libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
   ).
   jsSettings(
     // Scala.js cannot run forked tests
     fork in Test := false
   ).
-  jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin)).
-  jvmSettings(
-    libraryDependencies += "junit" % "junit" % "4.12" % "test",
-    libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
-  ).
-  jvmSettings(
-    mimaPreviousVersion := None
-  )
+  jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
 
 lazy val `scala-parser-combinatorsJVM` = `scala-parser-combinators`.jvm
 lazy val `scala-parser-combinatorsJS` = `scala-parser-combinators`.js

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ScalaModulePlugin._
 scalaVersionsByJvm in ThisBuild := {
   val v211 = "2.11.12"
   val v212 = "2.12.4"
-  val v213 = "2.13.0-M2"
+  val v213 = "2.13.0-M3"
 
   Map(
     6 -> List(v211 -> true),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-lang.modules" % "scala-module-plugin" % "1.0.8")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.13")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.16")
+addSbtPlugin("org.scala-js"     % "sbt-scalajs"              % "0.6.22")


### PR DESCRIPTION
This:
 - merges `1.0.x` into master
 - bumps the scala version to `2.13.0-M3` (and sbt to `0.13.17`)

Then we can release 1.1.0 with 2.13.0-M3 support 🎉!