### PR TITLE
Added CharSequenceReader.toString

### DIFF
--- a/shared/src/main/scala/scala/util/parsing/input/CharSequenceReader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/CharSequenceReader.scala
@@ -63,4 +63,12 @@ class CharSequenceReader(override val source: java.lang.CharSequence,
    */
   override def drop(n: Int): CharSequenceReader =
     new CharSequenceReader(source, offset + n)
+
+  /** Returns a String in the form `CharSequenceReader(first, ...)`,
+   *  or `CharSequenceReader()` if this is `atEnd`.
+   */
+  override def toString: String = {
+    val c = if (atEnd) "" else s"'$first', ..."
+    s"CharSequenceReader($c)"
+  }
 }


### PR DESCRIPTION
improved log() by adding CharSequenceReader.toString

current: trying foo at CharSequenceReader@abcd
proposed: trying foo at CharSequenceReader('#', ...)