### PR TITLE
fix warning in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import ScalaModulePlugin._
+import sbtcrossproject.crossProject
 
 scalaVersionsByJvm in ThisBuild := {
   val v211 = "2.11.12"
@@ -17,7 +18,7 @@ lazy val root = project.in(file("."))
   .aggregate(`scala-parser-combinatorsJS`, `scala-parser-combinatorsJVM`)
   .settings(disablePublishing)
 
-lazy val `scala-parser-combinators` = crossProject.in(file(".")).
+lazy val `scala-parser-combinators` = crossProject(JSPlatform, JVMPlatform).in(file(".")).
   settings(scalaModuleSettings: _*).
   jvmSettings(scalaModuleSettingsJVM).
   settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.14")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.23")
+
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")


### PR DESCRIPTION
https://github.com/portable-scala/sbt-crossproject/tree/f1a6e1c7c#cross-compiling-scalajs-jvm-and-native

```
build.sbt:20: warning: method crossProjectFromBuilder in trait CrossProjectExtra is deprecated: The built-in cross-project feature of sbt-scalajs is deprecated. Use the separate sbt plugin sbt-crossproject instead: https://github.com/portable-scala/sbt-crossproject
lazy val `scala-parser-combinators` = crossProject.in(file(".")).
                                      ^
```