### PR TITLE
allow building on JDK 10/11; add JDK 10 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,12 @@ jdk:
   - openjdk6
   - oraclejdk8
   - oraclejdk9
+  - oraclejdk10
 
 notifications:
   email:
     - adriaan.moors@lightbend.com
+    - seth.tisue@lightbend.com
     - antoine@gourlay.fr
 
 before_cache:

--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,14 @@ scalaVersionsByJvm in ThisBuild := {
   val v212 = "2.12.6"
   val v213 = "2.13.0-M4"
 
+  val allFalse = List(v212 -> false, v213 -> false, v211 -> false)
   Map(
-    6 -> List(v211 -> true),
-    7 -> List(v211 -> false),
-    8 -> List(v212 -> true, v213 -> true, v211 -> false),
-    9 -> List(v212 -> false, v213 -> false, v211 -> false)
+    6  -> List(v211 -> true),
+    7  -> List(v211 -> false),
+    8  -> List(v212 -> true, v213 -> true, v211 -> false),
+    9  -> allFalse,
+    10 -> allFalse,
+    11 -> allFalse
   )
 }
 


### PR DESCRIPTION
we might consider dropping 9 soon

context: I'm getting a JDK 10 community build going