### PR TITLE
Fix JDK6 build: use http-only repos for JDK6

### DIFF
--- a/.sbtrepos
+++ b/.sbtrepos
@@ -1,0 +1,8 @@
+[repositories]
+  local
+  local-preloaded-ivy: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
+  local-preloaded: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
+  maven-central:  http://repo1.maven.org/maven2/
+  sonatype-public: http://oss.sonatype.org/content/repositories/public
+  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  sbt-ivy-releases: http://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -50,4 +50,8 @@ if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
   openssl aes-256-cbc -K $K -iv $IV -in admin/secring.asc.enc -out admin/secring.asc -d
 fi
 
-sbt "$publishVersion" "$publishScalaVersion" clean update +test +publishLocal $extraTarget
+if [[ "$TRAVIS_JDK_VERSION" == "openjdk6" ]]; then
+  SBTOPTS="-Dsbt.override.build.repos=true -Dsbt.repository.config=./.sbtrepos"
+fi
+
+sbt $SBTOPTS "$publishVersion" "$publishScalaVersion" clean update +test +publishLocal $extraTarget


### PR DESCRIPTION
Workaround the lack of TLS 1.2 support in JDK6 by using http to talk to
maven central, as done in scala/scala-xml#247.

See scala/sbt-scala-module#41.

Fixes #169.