### PR TITLE
Move build matrix to .travis.yml and reinstate scala-native support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,9 @@ matrix:
       jdk: openjdk6
     - scala: 2.13.0-M5
       jdk: openjdk6
+  include:
+    - env: SCALANATIVE_VERSION=0.3.8
+      jdk: oraclejdk8
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ env:
     - secure: "JSv/Er6q1XtTpRH1bpU63YBf7ufwg0vW+Kv/udQBtr8YX/P3gRYC1x6hW4uwftaKMYh7wXDkfNy51SRpH3kUptdJvjPUifVElyPiYlsumetmD+rZJmxX6agx+U5pdjIXPqPoton9MdSVHNTROeTu339bDak0Z+N5ht5wRfjP7F4="
     # SONA_PASS
     - secure: "OIVtcj7AHZr8Grpf03ZmZsygcADewiYIvSnRwLYCx+5AqOzs39EZ68DsIOxi7wEXVUbVj5RvLXpKzLX3iN+UszLOQRoFPFQyyn+3Y50f8T2aRxdZtInzXn0sCVTj4Hhd/zbKl1W+2Nh3Sqazab7tFoQVzEyYqhcPeiNRMF7h+aY="
+  matrix:
+    - SCALAJS_VERSION=
+    - SCALAJS_VERSION=0.6.25
 
 script:
   - echo $JAVA_HOME
@@ -36,6 +39,24 @@ jdk:
   - openjdk6
   - oraclejdk8
   - openjdk11
+
+scala:
+  - 2.11.12
+  - 2.12.7
+  - 2.13.0-M5
+
+matrix:
+  exclude:
+    - jdk: openjdk11
+      env: SCALAJS_VERSION=0.6.25
+    - scala: 2.11.12
+      jdk: oraclejdk8
+    - scala: 2.11.12
+      jdk: openjdk11
+    - scala: 2.12.7
+      jdk: openjdk6
+    - scala: 2.13.0-M5
+      jdk: openjdk6
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,7 @@ addons:
 jdk:
   - openjdk6
   - oraclejdk8
-  - oraclejdk9
-  - oraclejdk10
+  - openjdk11
 
 notifications:
   email:

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -4,54 +4,58 @@ set -e
 
 # Builds of tagged revisions are published to sonatype staging.
 
-# Travis runs a build on new revisions and on new tags, so a tagged revision is built twice.
+# Travis runs a build on new revisions, including on new tags.
 # Builds for a tag have TRAVIS_TAG defined, which we use for identifying tagged builds.
 # Checking the local git clone would not work because git on travis does not fetch tags.
 
 # The version number to be published is extracted from the tag, e.g., v1.2.3 publishes
-# version 1.2.3 using all Scala versions in build.sbt's `crossScalaVersions`.
+# version 1.2.3 using all Scala versions in the travis matrix where
+# [ "$RELEASE_COMBO" = "true" ].
 
-# When a new, binary incompatible Scala version becomes available, a previously released version
-# can be released using that new Scala version by creating a new tag containing the Scala and the
-# JVM version after hashes, e.g., v1.2.3#2.13.0-M1#8. The JVM version needs to be listed in
-# `.travis.yml`, otherwise the required build doesn't run.
+# In order to build a previously released version against a new (binary incompatible) Scala release,
+# a new commit that modifies (and prunes) the Scala versions in .travis.yml needs to be added on top
+# of the existing tag. Then a new tag can be created for that commit, e.g., `v1.2.3#2.13.0-M5`.
+# Everything after the `#` in the tag name is ignored.
+
+if [[ "$TRAVIS_JDK_VERSION" == "openjdk6" && "$TRAVIS_SCALA_VERSION" =~ 2\.11\..* \
+      || "$TRAVIS_JDK_VERSION" == "oraclejdk8" && "$TRAVIS_SCALA_VERSION" =~ 2\.1[23]\..* ]]; then
+  RELEASE_COMBO=true;
+fi
+
+if [ "$SCALAJS_VERSION" = "" ]; then
+  projectPrefix="scala-parser-combinators"
+else
+  projectPrefix="scala-parser-combinatorsJS"
+fi
 
 verPat="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?"
 tagPat="^v$verPat(#$verPat#[0-9]+)?$"
 
 if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
-  currentJvmVer=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/^1\.//' | sed 's/[^0-9].*//')
-
-  tagVer=$(echo $TRAVIS_TAG | sed s/#.*// | sed s/^v//)
+  tagVer=${TRAVIS_TAG}
+  tagVer=${tagVer#v}   # Remove `v` at beginning.
+  tagVer=${tagVer%%#*} # Remove anything after `#`.
   publishVersion='set every version := "'$tagVer'"'
 
-  scalaAndJvmVer=$(echo $TRAVIS_TAG | sed s/[^#]*// | sed s/^#//)
-  if [ "$scalaAndJvmVer" != "" ]; then
-    scalaVer=$(echo $scalaAndJvmVer | sed s/#.*//)
-    jvmVer=$(echo $scalaAndJvmVer | sed s/[^#]*// | sed s/^#//)
-    if [ "$jvmVer" != "$currentJvmVer" ]; then
-      echo "Not publishing $TRAVIS_TAG on Java version $currentJvmVer."
-      exit 0
-    fi
-    publishScalaVersion='set every ScalaModulePlugin.scalaVersionsByJvm := Map('$jvmVer' -> List("'$scalaVer'" -> true))'
-    echo "Releasing $tagVer using Scala $scalaVer on Java version $jvmVer."
-  else
-    echo "Releasing $tagVer on Java version $currentJvmVer according to 'scalaVersionsByJvm' in build.sbt."
+  if [ "$RELEASE_COMBO" = "true" ]; then
+    currentJvmVer=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | sed 's/^1\.//' | sed 's/[^0-9].*//')
+    echo "Releasing $tagVer with Scala $TRAVIS_SCALA_VERSION on Java version $currentJvmVer."
+
+    publishTask="$projectPrefix/publish-signed"
+
+    cat admin/gpg.sbt >> project/plugins.sbt
+    cp admin/publish-settings.sbt .
+
+    # Copied from the output of genKeyPair.sh
+    K=$encrypted_5e972ec514e2_key
+    IV=$encrypted_5e972ec514e2_iv
+
+    openssl aes-256-cbc -K $K -iv $IV -in admin/secring.asc.enc -out admin/secring.asc -d
   fi
-
-  extraTarget="+publish-signed"
-  cat admin/gpg.sbt >> project/plugins.sbt
-  cp admin/publish-settings.sbt .
-
-  # Copied from the output of genKeyPair.sh
-  K=$encrypted_5e972ec514e2_key
-  IV=$encrypted_5e972ec514e2_iv
-
-  openssl aes-256-cbc -K $K -iv $IV -in admin/secring.asc.enc -out admin/secring.asc -d
 fi
 
 if [[ "$TRAVIS_JDK_VERSION" == "openjdk6" ]]; then
   SBTOPTS="-Dsbt.override.build.repos=true -Dsbt.repository.config=./.sbtrepos"
 fi
 
-sbt $SBTOPTS "$publishVersion" "$publishScalaVersion" clean update +test +publishLocal $extraTarget
+sbt $SBTOPTS "++$TRAVIS_SCALA_VERSION" "$publishVersion" "$projectPrefix/update"  "$projectPrefix/compile" "$projectPrefix/test" "$projectPrefix/publishLocal" "$publishTask"

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -17,15 +17,21 @@ set -e
 # of the existing tag. Then a new tag can be created for that commit, e.g., `v1.2.3#2.13.0-M5`.
 # Everything after the `#` in the tag name is ignored.
 
-if [[ "$TRAVIS_JDK_VERSION" == "openjdk6" && "$TRAVIS_SCALA_VERSION" =~ 2\.11\..* \
+if [[ "$SCALANATIVE_VERSION" != "" ]]; then
+  if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" && "$TRAVIS_SCALA_VERSION" =~ 2\.11\..* ]]; then
+    RELEASE_COMBO=true;
+  fi
+elif [[ "$TRAVIS_JDK_VERSION" == "openjdk6" && "$TRAVIS_SCALA_VERSION" =~ 2\.11\..* \
       || "$TRAVIS_JDK_VERSION" == "oraclejdk8" && "$TRAVIS_SCALA_VERSION" =~ 2\.1[23]\..* ]]; then
   RELEASE_COMBO=true;
 fi
 
-if [ "$SCALAJS_VERSION" = "" ]; then
-  projectPrefix="scala-parser-combinators"
-else
+if ! [ "$SCALAJS_VERSION" == "" ]; then
   projectPrefix="scala-parser-combinatorsJS"
+elif ! [ "$SCALANATIVE_VERSION" == "" ]; then
+  projectPrefix="scala-parser-combinatorsNative"
+else
+  projectPrefix="scala-parser-combinators"
 fi
 
 verPat="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?"

--- a/build.sbt
+++ b/build.sbt
@@ -1,27 +1,14 @@
 import ScalaModulePlugin._
 import sbtcrossproject.crossProject
 
-scalaVersionsByJvm in ThisBuild := {
-  val v211 = "2.11.12"
-  val v212 = "2.12.7"
-  val v213 = "2.13.0-M5"
-
-  val allFalse = List(v212 -> false, v213 -> false, v211 -> false)
-  Map(
-    6  -> List(v211 -> true),
-    7  -> List(v211 -> false),
-    8  -> List(v212 -> true, v213 -> true, v211 -> false),
-    9  -> allFalse,
-    10 -> allFalse,
-    11 -> allFalse
-  )
-}
+crossScalaVersions in ThisBuild := List("2.12.7", "2.11.12", "2.13.0-M5")
 
 lazy val root = project.in(file("."))
   .aggregate(`scala-parser-combinatorsJS`, `scala-parser-combinatorsJVM`)
   .settings(disablePublishing)
 
-lazy val `scala-parser-combinators` = crossProject(JSPlatform, JVMPlatform).in(file(".")).
+lazy val `scala-parser-combinators` = crossProject(JSPlatform, JVMPlatform).
+  withoutSuffixFor(JVMPlatform).in(file(".")).
   settings(scalaModuleSettings: _*).
   jvmSettings(scalaModuleSettingsJVM).
   settings(

--- a/native/src/main/scala/scala/util/parsing/input/PositionCache.scala
+++ b/native/src/main/scala/scala/util/parsing/input/PositionCache.scala
@@ -1,0 +1,14 @@
+package scala.util.parsing.input
+
+import java.lang.CharSequence
+import java.util.{AbstractMap, Collections}
+
+private[input] trait PositionCache {
+  private[input] lazy val indexCache: java.util.Map[CharSequence,Array[Int]] = new AbstractMap[CharSequence, Array[Int]] {
+
+    override def entrySet() = Collections.emptySet()
+
+    // the /dev/null of Maps
+    override def put(ch: CharSequence, a: Array[Int]) = null
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,11 @@ val scalaJSVersion =
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
+val scalaNativeVersion =
+  Option(System.getenv("SCALANATIVE_VERSION")).filter(_.nonEmpty).getOrElse("0.3.8")
+
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % scalaNativeVersion)
+
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,6 +7,9 @@ else
 
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.14")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("0.6.25")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")


### PR DESCRIPTION
1. Move build matrix to .travis.yml: no more ScalaVersionByJvm.

This does the same thing as scala/scala-xml#223 but for parser-combinators:
 * the matrix build is moved to .travis.yml, with
   * jdk 6, 8 and 11
   * scala 2.11.12, 2.12.7 and 2.13.0-M5
   * JVM, JS 0.6.25 (and JS 1.0.0-M5 eventually)
   * a few combinations are disabled when not supported or superfluous
 * re-publishing is done by adding a commit above a tag with the version
   change and pushing a new tag
 * ScalaVersionByJvm is not used, crossScalaVersion is enough
---
2. And with that we can reinstate support for scala native:

It was reverted in #135 because of build problems, but this is very easy
to add now: we add a single 'jdk8 + scala 2.11.12' job to the build
matrix, and also restrict publishing to those versions to be sure.

Locally, the native subproject can be run with any jdk > 6 and works
normally.

fixes #141.