### PR TITLE
Take into account leading and trailing line endings

### DIFF
--- a/shared/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
@@ -34,14 +34,13 @@ case class OffsetPosition(source: CharSequence, offset: Int) extends Position {
 
   private def genIndex: Array[Int] = {
     val lineStarts = new ArrayBuffer[Int]
-    lineStarts += 0 // first line
-    for (i <- 1 until source.length) {
-      if (source.charAt(i - 1) == '\n') // \n or \r\n
-        lineStarts += i
-      else if (source.charAt(i - 1) == '\r' && source.charAt(i) != '\n') // \r but not \r\n
-        lineStarts += i
-    }
-    lineStarts += source.length // eof
+    lineStarts += 0
+    for (i <- 0 until source.length)
+      if (source.charAt(i) == '\n' ||
+        (source.charAt(i) == '\r' && (i == (source.length - 1) || source.charAt(i + 1) != '\n'))) {
+        lineStarts += (i + 1)
+      }
+    lineStarts += source.length
     lineStarts.toArray
   }
 

--- a/shared/src/test/scala/scala/util/parsing/input/OffsetPositionTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/input/OffsetPositionTest.scala
@@ -18,7 +18,7 @@ class OffsetPositionTest {
 
   @Test
   def lineContentsWithTrailingCRLF: Unit = {
-    val op = new OffsetPosition("\r\n", 1)
+    val op = new OffsetPosition("\r\n", 2)
     assertEquals("", op.lineContents)
   }
 
@@ -43,6 +43,42 @@ class OffsetPositionTest {
   @Test
   def linesWithCRLF: Unit = {
     val op = new OffsetPosition("foo\r\nbar", 5)
+    assertEquals(2, op.line)
+  }
+
+  @Test
+  def linesWithTrailingLFs: Unit = {
+    val op = new OffsetPosition("foo\n\n", 5)
+    assertEquals(3, op.line)
+  }
+
+  @Test
+  def linesWithTrailingCRs: Unit = {
+    val op = new OffsetPosition("foo\r\r", 5)
+    assertEquals(3, op.line)
+  }
+
+  @Test
+  def linesWithTrailingCRLFs: Unit = {
+    val op = new OffsetPosition("foo\r\n\r\n", 7)
+    assertEquals(3, op.line)
+  }
+
+  @Test
+  def linesWithLeadingLF: Unit = {
+    val op = new OffsetPosition("\n", 1)
+    assertEquals(2, op.line)
+  }
+
+  @Test
+  def linesWithLeadingCR: Unit = {
+    val op = new OffsetPosition("\r", 1)
+    assertEquals(2, op.line)
+  }
+
+  @Test
+  def linesWithLeadingCRLF: Unit = {
+    val op = new OffsetPosition("\r\n", 2)
     assertEquals(2, op.line)
   }
 }


### PR DESCRIPTION
This fixes a regression introduced in #164 