### PR TITLE
Add missing NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+Scala parser combinators
+Copyright (c) 2002-2019 EPFL
+Copyright (c) 2011-2019 Lightbend, Inc.
+
+Scala includes software developed at
+LAMP/EPFL (https://lamp.epfl.ch/) and
+Lightbend, Inc. (https://www.lightbend.com/).
+
+Licensed under the Apache License, Version 2.0 (the "License").
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
The header comments added to the class files in https://github.com/scala/scala-parser-combinators/pull/184 refer to a NOTICE file that isn't there. This PR adds that file.