### PR TITLE
remove vestiges of JDK 6 build

### DIFF
--- a/.sbtrepos
+++ b/.sbtrepos
@@ -1,8 +1,0 @@
-[repositories]
-  local
-  local-preloaded-ivy: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
-  local-preloaded: file:///${sbt.preloaded-${sbt.global.base-${user.home}/.sbt}/preloaded/}
-  maven-central:  http://repo1.maven.org/maven2/
-  sonatype-public: http://oss.sonatype.org/content/repositories/public
-  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
-  sbt-ivy-releases: http://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: scala
 jdk:
   - oraclejdk8

--- a/admin/README.md
+++ b/admin/README.md
@@ -40,8 +40,8 @@ env:
 script: admin/build.sh
 
 jdk:
-  - openjdk6
   - oraclejdk8
+  - openjdk11
 
 notifications:
   email:

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -21,8 +21,7 @@ if [[ "$SCALANATIVE_VERSION" != "" ]]; then
   if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" && "$TRAVIS_SCALA_VERSION" =~ 2\.11\..* ]]; then
     RELEASE_COMBO=true;
   fi
-elif [[ "$TRAVIS_JDK_VERSION" == "openjdk6" && "$TRAVIS_SCALA_VERSION" =~ 2\.11\..* \
-      || "$TRAVIS_JDK_VERSION" == "oraclejdk8" && "$TRAVIS_SCALA_VERSION" =~ 2\.1[23]\..* ]]; then
+elif [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]]; then
   RELEASE_COMBO=true;
 fi
 
@@ -60,8 +59,4 @@ if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
   fi
 fi
 
-if [[ "$TRAVIS_JDK_VERSION" == "openjdk6" ]]; then
-  SBTOPTS="-Dsbt.override.build.repos=true -Dsbt.repository.config=./.sbtrepos"
-fi
-
-sbt $SBTOPTS "++$TRAVIS_SCALA_VERSION" "$publishVersion" "$projectPrefix/update"  "$projectPrefix/compile" "$projectPrefix/test" "$projectPrefix/publishLocal" "$publishTask"
+sbt "++$TRAVIS_SCALA_VERSION" "$publishVersion" "$projectPrefix/update"  "$projectPrefix/compile" "$projectPrefix/test" "$projectPrefix/publishLocal" "$publishTask"


### PR DESCRIPTION
some of this is just cleanup, but there is an actual fix: we weren't setting RELEASE_COMBO correctly for the 2.11 build, so no 2.11 artifacts would be published
