### PR TITLE
Global / credentials

### DIFF
--- a/admin/publish-settings.sbt
+++ b/admin/publish-settings.sbt
@@ -6,4 +6,4 @@ pgpPublicRing := file("admin/pubring.asc")
 
 pgpSecretRing := file("admin/secring.asc")
 
-credentials   += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", env("SONA_USER"), env("SONA_PASS"))
+Global / credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", env("SONA_USER"), env("SONA_PASS"))


### PR DESCRIPTION
credentials probably should be scoped to Global here so it can be used by all subprojects.