### PR TITLE
Make RegexParser.err handle whitespace like literal and regex

### DIFF
--- a/shared/src/main/scala/scala/util/parsing/combinator/RegexParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/RegexParsers.scala
@@ -138,6 +138,22 @@ trait RegexParsers extends Parsers {
     }
   }
 
+  // we might want to make it public/protected in a future version
+  private def ws[T](p: Parser[T]): Parser[T] = new Parser[T] {
+    def apply(in: Input) = {
+      val offset = in.offset
+      val start = handleWhiteSpace(in.source, offset)
+      p(in.drop (start - offset))
+    }
+  }
+
+  /**
+    * @inheritdoc
+    *
+    * This parser additionally skips whitespace if `skipWhitespace` returns true.
+    */
+  override def err(msg: String) = ws(super.err(msg))
+
   /**
    * A parser generator delimiting whole phrases (i.e. programs).
    *

--- a/shared/src/test/scala/scala/util/parsing/combinator/RegexParsersTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/RegexParsersTest.scala
@@ -1,7 +1,7 @@
 package scala.util.parsing.combinator
 
 import org.junit.Test
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{ assertEquals, assertTrue }
 
 class RegexParsersTest {
   @Test
@@ -99,5 +99,20 @@ class RegexParsersTest {
 
     val success = parseAll(twoWords, "first second").asInstanceOf[Success[(String, String)]]
     assertEquals(("second", "first"), success.get)
+  }
+
+  @Test
+  def errorConsumesWhitespace: Unit = {
+    object parser extends RegexParsers {
+      def num = "\\d+".r
+
+      def twoNums =  num ~ (num | err("error!"))
+    }
+    import parser._
+
+    // this used to return a Failure (for the second num)
+    val error = parseAll(twoNums, "458   bar")
+    assertTrue(s"expected an Error but got: ${error.getClass.getName}", error.isInstanceOf[Error])
+    assertEquals("error!", error.asInstanceOf[Error].msg)
   }
 }

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh29.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh29.scala
@@ -1,0 +1,36 @@
+package scala.util.parsing.combinator
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class gh29 {
+  object Foo extends JavaTokenParsers {
+    def word(x: String) = s"\\b$x\\b".r
+
+    lazy val expr  = aSentence | something
+
+    lazy val aSentence = noun ~ verb ~ obj
+
+    lazy val noun   = word("noun")
+    lazy val verb   = word("verb") | err("not a verb!")
+    lazy val obj    = word("object")
+
+    lazy val something = word("FOO")
+  }
+
+  val expected =
+    """[1.6] error: not a verb!
+
+noun vedsfasdf
+     ^""".stripMargin
+
+  @Test
+  def test(): Unit = {
+    val f = Foo.parseAll(Foo.expr, "noun verb object")
+
+    assertEquals("[1.17] parsed: ((noun~verb)~object)", f.toString)
+
+    val g = Foo.parseAll(Foo.expr, "noun vedsfasdf")
+    assertEquals(expected, g.toString)
+  }
+}


### PR DESCRIPTION
This overrides `err` in RegexParser to make it consume whitespace just
like regex and literal. The original motivation was:

```
object parser extends RegexParsers {
  def num = "\\d+".r

  def twoNums =  num ~ (num | err("error!"))
}

// succeeds
parser.parseAll(twoNums, "42    721")

// fails with a parsing Failure instead of an Error
// because err doesn't consume the whitespace but the regex does.
parser.parseAll(twoNums, "42    foo")
```

This may change the output of some parsers that failed to parse input
(from a Failure to an Error).

fixes #29, reintroduction of #30 