### PR TITLE
Add scala native to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,11 @@ env:
     - SCALAJS_VERSION=0.6.27
     - SCALAJS_VERSION=1.0.0-M7
 
+matrix:
+  include:
+    - env: SCALANATIVE_VERSION=0.3.8
+      jdk: oraclejdk8
+
 script: admin/build.sh
 
 notifications:


### PR DESCRIPTION
Applying this PR will add Scala native to the build matrix again, looks like it was removed by accident in #184.