### PR TITLE
Update release tag pattern

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -1,11 +1,5 @@
 ## Tag Driven Releasing
 
-### Background Reading
-
-  - http://docs.travis-ci.com/user/environment-variables/
-  - http://docs.travis-ci.com/user/encryption-keys/
-  - http://docs.travis-ci.com/user/encrypting-files/
-
 ### Initial setup for the repository
 
 To configure tag driven releases from Travis CI.
@@ -13,15 +7,15 @@ To configure tag driven releases from Travis CI.
   1. Generate a key pair for this repository with `./admin/genKeyPair.sh`.
      Edit `.travis.yml` and `admin/build.sh` as prompted.
   1. Publish the public key to https://pgp.mit.edu
-  1. Store other secrets as encrypted environment variables with `admin/encryptEnvVars.sh`.
+  1. Store other secrets as encrypted environment variables with `./admin/encryptEnvVars.sh`.
      Edit `.travis.yml` as prompted.
   1. Edit `.travis.yml` to use `./admin/build.sh` as the build script,
      and edit that script to use the tasks required for this project.
-  1. Edit `build.sbt`'s `scalaVersionsByJvm in ThisBuild` to select Scala and JVM version
-     combinations that will be used for publishing.
+     Ensure that `RELEASE_COMBO` is `true` for build matrix combinations
+     that should be released to sonatype (when building a tag).
 
 It is important to add comments in `.travis.yml` to identify the name
-of each environment variable encoded in a `:secure` section.
+of each environment variable encoded in a `secure` section.
 
 After these steps, your `.travis.yml` should contain config of the form:
 
@@ -37,7 +31,8 @@ env:
     # SONA_PASS
     - secure: "XXXXXX"
 
-script: admin/build.sh
+script:
+  - admin/build.sh
 
 jdk:
   - oraclejdk8
@@ -62,10 +57,9 @@ without generating a new key.
   1. Create a GitHub "Release" with a corresponding tag (e.g., `v0.1.1`) via the GitHub
      web interface.
   1. The release will be published using the Scala and JVM version combinations specified
-     in `scalaVersionsByJvm` in `build.sbt`.
-     - If you need to release against a different Scala version, include the Scala version
-       and the JVM version to use in the tag name, separated by `#`s (e.g., `v0.1.1#2.13.0-M1#8`).
-       Note that the JVM version needs to be listed in `.travis.yml` for the build to run.
+     in the travis build matrix where `[ "$RELEASE_COMBO" = "true" ]`.
+     - If you need to release against a different Scala version, create a new commit that modifies
+       `.travis.yml` and push a new tag, e.g., `v1.2.3#2.13.0-M5`. The suffix after `#` is ignored.
   1. Travis CI will schedule a build for this release. Review the build logs.
   1. Log into https://oss.sonatype.org/ and identify the staging repository.
   1. Sanity check its contents.

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -34,7 +34,7 @@ else
 fi
 
 verPat="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?"
-tagPat="^v$verPat(#$verPat#[0-9]+)?$"
+tagPat="^v$verPat(#.*)?$"
 
 if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
   tagVer=${TRAVIS_TAG}

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -13,9 +13,9 @@ set -e
 # [ "$RELEASE_COMBO" = "true" ].
 
 # In order to build a previously released version against a new (binary incompatible) Scala release,
-# a new commit that modifies (and prunes) the Scala versions in .travis.yml needs to be added on top
-# of the existing tag. Then a new tag can be created for that commit, e.g., `v1.2.3#2.13.0-M5`.
-# Everything after the `#` in the tag name is ignored.
+# add a new commit that modifies (and prunes) the Scala versions in .travis.yml on top of the existing tag.
+# Then add a new tag for that commit, e.g., `v1.1.2#2.13.0-M5`. or `v1.1.2#native`. Everything after the `#`
+# in the tag name is ignored. Push the tag (the commit doesn't need to be on any branch).
 
 if [[ "$SCALANATIVE_VERSION" != "" ]]; then
   if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" && "$TRAVIS_SCALA_VERSION" =~ 2\.11\..* ]]; then


### PR DESCRIPTION
Applying this PR will:

- update the release tag pattern so that for example `v1.1.2#native` is possible:
   - allowing text in the release tag after the first `#`
   - removing the need of adding a second `#` with the java version 
- update the documentation, following https://github.com/scala/scala-xml/pull/223