### PR TITLE
allow JDK 13/14 build (on 1.0.x branch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,9 @@ env:
 
 script: admin/build.sh
 
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
-
 jdk:
   - openjdk6
-  - oraclejdk8
+  - openjdk8
 
 notifications:
   email:

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,9 @@ scalaVersionsByJvm in ThisBuild := {
     9 -> List(v212 -> false, v213 -> false, v211 -> false),
     10 -> List(v212 -> false, v213 -> false, v211 -> false),
     11 -> List(v212 -> false, v213 -> false, v211 -> false),
-    12 -> List(v212 -> false, v213 -> false, v211 -> false)
+    12 -> List(v212 -> false, v213 -> false, v211 -> false),
+    13 -> List(v212 -> false, v213 -> false, v211 -> false),
+    14 -> List(v212 -> false, v213 -> false, v211 -> false)
   )
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.13")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "1.0.14")
 
 addSbtPlugin("org.scala-js"     % "sbt-scalajs"              % "0.6.22")


### PR DESCRIPTION
note that the Travis-CI changes don't make the JDK 6 build work, but they do allow the JDK 8 one to run, at least

the context for this is https://github.com/scala/community-build/issues/984