### PR TITLE
Add dotty to cross-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ import: scala/scala-dev:travis/default.yml
 language: scala
 
 scala:
+  - 0.22.0-RC1
   - 2.11.12
   - 2.12.10
   - 2.13.1
@@ -16,6 +17,11 @@ env:
   - ADOPTOPENJDK=11    SCALAJS_VERSION=
 
 matrix:
+  exclude:
+    - scala: 0.22.0-RC1
+      env: ADOPTOPENJDK=8     SCALAJS_VERSION=0.6.32
+    - scala: 0.22.0-RC1
+      env: ADOPTOPENJDK=8     SCALAJS_VERSION=1.0.1
   include:
     - scala: 2.11.12
       env: ADOPTOPENJDK=8     SCALANATIVE_VERSION=0.3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ import: scala/scala-dev:travis/default.yml
 language: scala
 
 scala:
-  - 0.22.0-RC1
+  - 0.23.0-RC1
   - 2.11.12
   - 2.12.10
   - 2.13.1
@@ -18,9 +18,9 @@ env:
 
 matrix:
   exclude:
-    - scala: 0.22.0-RC1
+    - scala: 0.23.0-RC1
       env: ADOPTOPENJDK=8     SCALAJS_VERSION=0.6.32
-    - scala: 0.22.0-RC1
+    - scala: 0.23.0-RC1
       env: ADOPTOPENJDK=8     SCALAJS_VERSION=1.0.1
   include:
     - scala: 2.11.12

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
       (unmanagedSourceDirectories in Compile).value.map { dir =>
         CrossVersion.partialVersion(scalaVersion.value) match {
           case Some((2, 13)) => file(dir.getPath ++ "-2.13+")
+          case Some((0, _))  => file(dir.getPath ++ "-2.13+")
           case _             => file(dir.getPath ++ "-2.13-")
         }
       }

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
   )
   .jsSettings(
+    crossScalaVersions -= "0.22.0-RC1",
     // Scala.js cannot run forked tests
     fork in Test := false
   )

--- a/build.sbt
+++ b/build.sbt
@@ -11,19 +11,22 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
     apiMappings += (scalaInstance.value.libraryJar ->
         url(s"https://www.scala-lang.org/api/${scalaVersion.value}/")),
 
-    scalacOptions in (Compile, doc) ++= Seq(
-      "-diagrams",
-      "-doc-source-url",
-      s"https://github.com/scala/scala-parser-combinators/tree/v${version.value}€{FILE_PATH}.scala",
-      "-sourcepath",
-      (baseDirectory in LocalRootProject).value.absolutePath,
-      "-doc-title",
-      "Scala Parser Combinators",
-      "-doc-version",
-      version.value,
-      if (isDotty.value) "-language:Scala2"
-      else ""
-    ),
+    scalacOptions in (Compile, doc) ++= {
+      if (isDotty.value)
+        Seq("-language:Scala2")
+      else
+        Seq(
+          "-diagrams",
+          "-doc-source-url",
+          s"https://github.com/scala/scala-parser-combinators/tree/v${version.value}€{FILE_PATH}.scala",
+          "-sourcepath",
+          (baseDirectory in LocalRootProject).value.absolutePath,
+          "-doc-title",
+          "Scala Parser Combinators",
+          "-doc-version",
+          version.value
+        )
+    },
     unmanagedSourceDirectories in Compile ++= {
       (unmanagedSourceDirectories in Compile).value.map { dir =>
         CrossVersion.partialVersion(scalaVersion.value) match {

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,9 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
       "-doc-title",
       "Scala Parser Combinators",
       "-doc-version",
-      version.value
+      version.value,
+      if (isDotty.value) "-language:Scala2"
+      else ""
     ),
     unmanagedSourceDirectories in Compile ++= {
       (unmanagedSourceDirectories in Compile).value.map { dir =>

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
   )
   .jsSettings(
-    crossScalaVersions -= "0.22.0-RC1",
+    crossScalaVersions -= "0.23.0-RC1",
     // Scala.js cannot run forked tests
     fork in Test := false
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % scalaNativeVersion)
+
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.0")

--- a/shared/src/main/scala/scala/util/parsing/combinator/ImplicitConversions.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/ImplicitConversions.scala
@@ -33,14 +33,14 @@ import scala.language.implicitConversions
  * @author Adriaan Moors
  */
 trait ImplicitConversions { self: Parsers =>
-  implicit def flatten2[A, B, C]         (f: (A, B) => C) =
+  implicit def flatten2[A, B, C]         (f: (A, B) => C): A ~ B => C =
     (p: ~[A, B]) => p match {case a ~ b => f(a, b)}
-  implicit def flatten3[A, B, C, D]      (f: (A, B, C) => D) =
+  implicit def flatten3[A, B, C, D]      (f: (A, B, C) => D): A ~ B ~ C => D =
     (p: ~[~[A, B], C]) => p match {case a ~ b ~ c => f(a, b, c)}
-  implicit def flatten4[A, B, C, D, E]   (f: (A, B, C, D) => E) =
+  implicit def flatten4[A, B, C, D, E]   (f: (A, B, C, D) => E): A ~ B ~ C ~ D => E =
     (p: ~[~[~[A, B], C], D]) => p match {case a ~ b ~ c ~ d => f(a, b, c, d)}
-  implicit def flatten5[A, B, C, D, E, F](f: (A, B, C, D, E) => F) =
+  implicit def flatten5[A, B, C, D, E, F](f: (A, B, C, D, E) => F): A ~ B ~ C ~ D ~ E => F =
     (p: ~[~[~[~[A, B], C], D], E]) => p match {case a ~ b ~ c ~ d ~ e=> f(a, b, c, d, e)}
-  implicit def headOptionTailToFunList[A, T] (f: List[A] => T)=
+  implicit def headOptionTailToFunList[A, T] (f: List[A] => T): A ~ Option[List[A]] => T =
     (p: ~[A, Option[List[A]]]) => f(p._1 :: (p._2 match { case Some(xs) => xs case None => Nil}))
 }

--- a/shared/src/main/scala/scala/util/parsing/combinator/JavaTokenParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/JavaTokenParsers.scala
@@ -14,6 +14,7 @@ package scala
 package util.parsing.combinator
 
 import scala.annotation.migration
+import scala.language.implicitConversions
 
 /** `JavaTokenParsers` differs from [[scala.util.parsing.combinator.RegexParsers]]
  *  by adding the following definitions:

--- a/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
@@ -107,7 +107,7 @@ trait PackratParsers extends Parsers {
     val q = super.phrase(p)
     new PackratParser[T] {
       def apply(in: Input) = in match {
-        case in if in.isInstanceOf[PackratReader[_]] => q(in)
+        case in if in.isInstanceOf[PackratReader[_]] => q(in) // TODO: try to change back to "case in: PackratReader[_]" after https://github.com/lampepfl/dotty/pull/8413
         case in => q(new PackratReader(in))
       }
     }

--- a/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
@@ -107,7 +107,7 @@ trait PackratParsers extends Parsers {
     val q = super.phrase(p)
     new PackratParser[T] {
       def apply(in: Input) = in match {
-        case in if in.isInstanceOf[PackratReader[_]] => q(in) // TODO: try to change back to "case in: PackratReader[_]" after https://github.com/lampepfl/dotty/pull/8413
+        case in: PackratReader[_] => q(in)
         case in => q(new PackratReader(in))
       }
     }

--- a/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
@@ -107,7 +107,7 @@ trait PackratParsers extends Parsers {
     val q = super.phrase(p)
     new PackratParser[T] {
       def apply(in: Input) = in match {
-        case in: PackratReader[_] => q(in)
+        case in if in.isInstanceOf[PackratReader[_]] => q(in)
         case in => q(new PackratReader(in))
       }
     }

--- a/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
@@ -663,8 +663,9 @@ trait Parsers {
    *  @param  es the list of expected elements
    *  @return a Parser that recognizes a specified list of elements
    */
-  def acceptSeq[ES](es: ES)(implicit f: ES => Iterable[Elem]): Parser[List[Elem]] =
-    es.foldRight[Parser[List[Elem]]](success(Nil)){(x, pxs) => accept(x) ~ pxs ^^ mkList}
+  def acceptSeq[ES](es: ES)(implicit f: ES => Iterable[Elem]): Parser[List[Elem]] = {
+    f(es).foldRight[Parser[List[Elem]]](success(Nil)){(x, pxs) => accept(x) ~ pxs ^^ mkList}
+  }
 
   /** A parser that always fails.
    *

--- a/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
@@ -664,7 +664,8 @@ trait Parsers {
    *  @return a Parser that recognizes a specified list of elements
    */
   def acceptSeq[ES](es: ES)(implicit f: ES => Iterable[Elem]): Parser[List[Elem]] = {
-    f(es).foldRight[Parser[List[Elem]]](success(Nil)){(x, pxs) => accept(x) ~ pxs ^^ mkList}
+    f(es) // explicit conversion for dotty
+      .foldRight[Parser[List[Elem]]](success(Nil)){(x, pxs) => accept(x) ~ pxs ^^ mkList}
   }
 
   /** A parser that always fails.

--- a/shared/src/main/scala/scala/util/parsing/combinator/lexical/StdLexical.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/lexical/StdLexical.scala
@@ -18,6 +18,7 @@ package lexical
 import token._
 import input.CharArrayReader.EofCh
 import scala.collection.mutable
+import scala.language.implicitConversions
 
 /** This component provides a standard lexical parser for a simple,
  *  [[http://scala-lang.org Scala]]-like language. It parses keywords and

--- a/shared/src/main/scala/scala/util/parsing/combinator/syntactical/StandardTokenParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/syntactical/StandardTokenParsers.scala
@@ -25,7 +25,7 @@ import scala.language.implicitConversions
  */
 class StandardTokenParsers extends StdTokenParsers {
   type Tokens = StdTokens
-  val lexical: StdLexical = new StdLexical()
+  val lexical: StdLexical = new StdLexical() // type annotation added for dotty
 
   //an implicit keyword function that gives a warning when a given word is not in the reserved/delimiters list
   override implicit def keyword(chars : String): Parser[String] =

--- a/shared/src/main/scala/scala/util/parsing/combinator/syntactical/StandardTokenParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/syntactical/StandardTokenParsers.scala
@@ -25,7 +25,7 @@ import scala.language.implicitConversions
  */
 class StandardTokenParsers extends StdTokenParsers {
   type Tokens = StdTokens
-  val lexical = new StdLexical
+  val lexical: StdLexical = new StdLexical()
 
   //an implicit keyword function that gives a warning when a given word is not in the reserved/delimiters list
   override implicit def keyword(chars : String): Parser[String] =

--- a/shared/src/test/scala/scala/util/parsing/combinator/JavaTokenParsersTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/JavaTokenParsersTest.scala
@@ -1,5 +1,6 @@
 package scala.util.parsing.combinator
 
+import scala.language.implicitConversions
 import scala.util.parsing.input.CharArrayReader
 
 import org.junit.Test

--- a/shared/src/test/scala/scala/util/parsing/combinator/PackratParsersTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/PackratParsersTest.scala
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 
+import scala.language.implicitConversions
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
 
 class PackratParsersTest {

--- a/shared/src/test/scala/scala/util/parsing/combinator/PackratParsersTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/PackratParsersTest.scala
@@ -17,6 +17,8 @@ class PackratParsersTest {
     def extractResult(r : ParseResult[Int]): Int = r match {
       case Success(a,_) => a
       case NoSuccess(a,_) => sys.error(a)
+      case Failure(a, _) => sys.error(a)
+      case Error(a, _) => sys.error(a)
     }
     def check(expected: Int, expr: String): Unit = {
       val parseResult = head(new lexical.Scanner(expr))
@@ -71,6 +73,8 @@ class PackratParsersTest {
     def extractResult(r : ParseResult[Int]): Int = r match {
       case Success(a,_) => a
       case NoSuccess(a,_) => sys.error(a)
+      case Failure(a, _) => sys.error(a)
+      case Error(a, _) => sys.error(a)
     }
     def check(expected: Int, expr: String): Unit = {
       val parseResult = head(new lexical.Scanner(expr))
@@ -94,6 +98,8 @@ class PackratParsersTest {
     def extractResult(r: ParseResult[AnBnCnResult]): AnBnCnResult = r match {
       case Success(a,_) => a
       case NoSuccess(a,_) => sys.error(a)
+      case Failure(a, _) => sys.error(a)
+      case Error(a, _) => sys.error(a)
     }
     def threeLists(as: List[Symbol], bs: List[Symbol], cs: List[Symbol]): AnBnCnResult = {
       val as1 = as.map(_.name)

--- a/shared/src/test/scala/scala/util/parsing/combinator/PackratParsersTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/PackratParsersTest.scala
@@ -140,14 +140,14 @@ private object grammars1 extends StandardTokenParsers with PackratParsers {
    */
 
 
- val term: PackratParser[Int] = (term~("+"~>fact) ^^ {case x~y => x+y}
-           |term~("-"~>fact) ^^ {case x~y => x-y}
-           |fact)
+   val term: PackratParser[Int] = (term~("+"~>fact) ^^ {case x~y => x+y}
+             |term~("-"~>fact) ^^ {case x~y => x-y}
+             |fact)
 
- val fact: PackratParser[Int] = (fact~("*"~>numericLit) ^^ {case x~y => x*y.toInt}
-           |fact~("/"~>numericLit) ^^ {case x~y => x/y.toInt}
-           |"("~>term<~")"
-           |numericLit ^^ {_.toInt})
+   val fact: PackratParser[Int] = (fact~("*"~>numericLit) ^^ {case x~y => x*y.toInt}
+             |fact~("/"~>numericLit) ^^ {case x~y => x/y.toInt}
+             |"("~>term<~")"
+             |numericLit ^^ {_.toInt})
 }
 
 private object grammars2 extends StandardTokenParsers with PackratParsers {

--- a/shared/src/test/scala/scala/util/parsing/combinator/RegexParsersTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/RegexParsersTest.scala
@@ -1,5 +1,7 @@
 package scala.util.parsing.combinator
 
+import scala.language.implicitConversions
+
 import org.junit.Test
 import org.junit.Assert.{ assertEquals, assertTrue }
 

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh242.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh242.scala
@@ -1,6 +1,7 @@
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+import scala.language.implicitConversions
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.CharSequenceReader
 

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh29.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh29.scala
@@ -2,6 +2,7 @@ package scala.util.parsing.combinator
 
 import org.junit.Test
 import org.junit.Assert.assertEquals
+import scala.language.implicitConversions
 
 class gh29 {
   object Foo extends JavaTokenParsers {

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh45.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh45.scala
@@ -1,5 +1,6 @@
 package scala.util.parsing.combinator
 
+import scala.language.implicitConversions
 import scala.util.parsing.input._
 
 import org.junit.Test

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh72.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh72.scala
@@ -1,3 +1,4 @@
+import scala.language.implicitConversions
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.CharSequenceReader
 

--- a/shared/src/test/scala/scala/util/parsing/combinator/t0700.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t0700.scala
@@ -1,5 +1,6 @@
 import java.io.{File,StringReader}
 
+import scala.language.implicitConversions
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.{CharArrayReader, StreamReader}
 

--- a/shared/src/test/scala/scala/util/parsing/combinator/t1100.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t1100.scala
@@ -12,7 +12,7 @@ class T1100 {
     def p1: Parser[Char] = accept('a') | err("errors are propagated")
   }
 
-val expected = """[1.4] error: errors are propagated
+  val expected = """[1.4] error: errors are propagated
 
 aaab
    ^"""

--- a/shared/src/test/scala/scala/util/parsing/combinator/t1229.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t1229.scala
@@ -2,6 +2,7 @@ import scala.util.parsing.combinator.RegexParsers
 
 import org.junit.Test
 import org.junit.Assert.assertEquals
+import scala.language.implicitConversions
 
 class t1229 extends RegexParsers {
   val number = """0|[1-9]\d*""".r ^^ { _.toInt }

--- a/shared/src/test/scala/scala/util/parsing/combinator/t3212.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t3212.scala
@@ -2,6 +2,7 @@ package scala.util.parsing.combinator
 
 import org.junit.Test
 import org.junit.Assert.assertEquals
+import scala.language.implicitConversions
 
 class t3212 extends RegexParsers {
 

--- a/shared/src/test/scala/scala/util/parsing/combinator/t5514.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t5514.scala
@@ -1,3 +1,4 @@
+import scala.language.implicitConversions
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.Reader
 import scala.util.parsing.input.Position

--- a/shared/src/test/scala/scala/util/parsing/combinator/t5669.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t5669.scala
@@ -1,5 +1,6 @@
 package scala.util.parsing.combinator
 
+import scala.language.implicitConversions
 import scala.util.parsing.input.OffsetPosition
 
 import org.junit.Test

--- a/shared/src/test/scala/scala/util/parsing/combinator/t6067.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t6067.scala
@@ -2,6 +2,7 @@ import scala.util.parsing.combinator._
 
 import org.junit.Test
 import org.junit.Assert.assertEquals
+import scala.language.implicitConversions
 
 class t6067 extends RegexParsers {
   object TestParser extends RegexParsers {

--- a/shared/src/test/scala/scala/util/parsing/combinator/t6464.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t6464.scala
@@ -1,3 +1,4 @@
+import scala.language.implicitConversions
 import scala.util.parsing.input.CharSequenceReader
 import scala.util.parsing.combinator.RegexParsers
 

--- a/shared/src/test/scala/scala/util/parsing/input/OffsetPositionTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/input/OffsetPositionTest.scala
@@ -2,6 +2,7 @@ package scala.util.parsing.input
 
 import org.junit.Test
 import org.junit.Assert.assertEquals
+import scala.language.implicitConversions
 
 class OffsetPositionTest {
   @Test

--- a/shared/src/test/scala/scala/util/parsing/input/gh178.scala
+++ b/shared/src/test/scala/scala/util/parsing/input/gh178.scala
@@ -2,6 +2,7 @@ package scala.util.parsing.input
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import scala.language.implicitConversions
 
 class gh178 {
 

--- a/shared/src/test/scala/scala/util/parsing/input/gh64.scala
+++ b/shared/src/test/scala/scala/util/parsing/input/gh64.scala
@@ -2,6 +2,7 @@ package scala.util.parsing.input
 
 import org.junit.Assert._
 import org.junit.Test
+import scala.language.implicitConversions
 
 class gh64 {
 


### PR DESCRIPTION
I'm down to three errors on this one:

```
[error] -- [E007] Type Mismatch Error: /home/travis/build/scala/scala-parser-combinators/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala:110:39 
[error] 110 |        case in: PackratReader[_] => q(in)
[error]     |                                       ^^
[error]     |                 Found:    (in : PackratParsers.this.PackratReader[_])
[error]     |                 Required: PackratParsers.this.Input
[error] -- [E008] Member Not Found Error: /home/travis/build/scala/scala-parser-combinators/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala:667:7 
[error] 667 |    es.foldRight[Parser[List[Elem]]](success(Nil)){(x, pxs) => accept(x) ~ pxs ^^ mkList}
[error]     |    ^^^^^^^^^^^^
[error]     |    value foldRight is not a member of ES
[error] -- [E008] Member Not Found Error: /home/travis/build/scala/scala-parser-combinators/shared/src/main/scala/scala/util/parsing/combinator/syntactical/StandardTokenParsers.scala:32:15 
[error] 32 |    if(lexical.reserved.contains(chars) || lexical.delimiters.contains(chars)) super.keyword(chars)
[error]    |       ^^^^^^^^^^^^^^^^
[error]    |      value reserved is not a member of StandardTokenParsers.this.Tokens
```