### PR TITLE
misc cleanups, go (nearly) warning-free

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,15 @@
-import sbtcrossproject.CrossPlugin.autoImport.crossProject
+lazy val root = project.in(file("."))
+  .aggregate(parserCombinatorsJVM, parserCombinatorsJS, parserCombinatorsNative)
+  .settings(
+    publish / skip := true,
+  )
 
 lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatform)
-  .withoutSuffixFor(JVMPlatform).in(file("."))
-  .settings(ScalaModulePlugin.scalaModuleSettings)
-  .jvmSettings(ScalaModulePlugin.scalaModuleOsgiSettings)
+  .in(file("."))
   .settings(
+    ScalaModulePlugin.scalaModuleSettings,
     name := "scala-parser-combinators",
-    scalaModuleMimaPreviousVersion := None,
+    scalaModuleMimaPreviousVersion := None,  // until we publish 1.2.0
 
     apiMappings ++= scalaInstance.value.libraryJars.collect {
       case file if file.getName.startsWith("scala-library") && file.getName.endsWith(".jar") =>
@@ -40,6 +43,7 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
     }
   )
   .jvmSettings(
+    ScalaModulePlugin.scalaModuleOsgiSettings,
     OsgiKeys.exportPackage := Seq(s"scala.util.parsing.*;version=${version.value}"),
     libraryDependencies += "junit" % "junit" % "4.13.1" % Test,
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
@@ -59,3 +63,7 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
       else libraryDependencies.value
     }
   )
+
+lazy val parserCombinatorsJVM    = parserCombinators.jvm
+lazy val parserCombinatorsJS     = parserCombinators.js
+lazy val parserCombinatorsNative = parserCombinators.native

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
         file -> url(s"http://www.scala-lang.org/api/${scalaVersion.value}/")
     }.toMap,
 
-    scalacOptions in (Compile, doc) ++= {
+    Compile / doc / scalacOptions ++= {
       if (isDotty.value)
         Seq("-language:Scala2")
       else
@@ -22,15 +22,15 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
           "-doc-source-url",
           s"https://github.com/scala/scala-parser-combinators/tree/v${version.value}€{FILE_PATH}.scala",
           "-sourcepath",
-          (baseDirectory in LocalRootProject).value.absolutePath,
+          (LocalRootProject / baseDirectory).value.absolutePath,
           "-doc-title",
           "Scala Parser Combinators",
           "-doc-version",
           version.value
         )
     },
-    unmanagedSourceDirectories in Compile ++= {
-      (unmanagedSourceDirectories in Compile).value.map { dir =>
+    Compile / unmanagedSourceDirectories ++= {
+      (Compile / unmanagedSourceDirectories).value.map { dir =>
         CrossVersion.partialVersion(scalaVersion.value) match {
           case Some((2, 13)) => file(dir.getPath ++ "-2.13+")
           case Some((0, _))  => file(dir.getPath ++ "-2.13+")
@@ -47,11 +47,11 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
   .jsSettings(
     crossScalaVersions -= "0.27.0-RC1",
     // Scala.js cannot run forked tests
-    fork in Test := false
+    Test / fork := false
   )
   .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
   .nativeSettings(
-    skip in compile := System.getProperty("java.version").startsWith("1.6") || !scalaVersion.value.startsWith("2.11"),
+    compile / skip := System.getProperty("java.version").startsWith("1.6") || !scalaVersion.value.startsWith("2.11"),
     test := {},
     libraryDependencies := {
       if (!scalaVersion.value.startsWith("2.11"))

--- a/build.sh
+++ b/build.sh
@@ -16,9 +16,9 @@ set -e
 # - commit the changes and tag this new revision with an arbitrary suffix after a hash, e.g.,
 #   `v1.2.3#dotty-0.27` (the suffix is ignored, the version will be `1.2.3`)
 
-# For normal tags that are cross-built, we release on JDK 8 for Scala 2.x
+# We release on JDK 8 (for Scala 2.x and Dotty 0.x)
 isReleaseJob() {
-  if [[ "$ADOPTOPENJDK" == "8" && "$TRAVIS_SCALA_VERSION" =~ ^2\.1[01234]\..*$ ]]; then
+  if [[ "$ADOPTOPENJDK" == "8" ]]; then
     true
   else
     false
@@ -26,11 +26,11 @@ isReleaseJob() {
 }
 
 if [[ "$SCALAJS_VERSION" != "" ]]; then
-  projectPrefix="parserCombinatorsJS"
+  projectPrefix="parserCombinatorsJS/"
 elif [[ "$SCALANATIVE_VERSION" != "" ]]; then
-  projectPrefix="parserCombinatorsNative"
+  projectPrefix="parserCombinatorsNative/"
 else
-  projectPrefix="parserCombinators"
+  projectPrefix="parserCombinatorsJVM/"
 fi
 
 verPat="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?"
@@ -45,12 +45,12 @@ if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
 fi
 
 # default is +publishSigned; we cross-build with travis jobs, not sbt's crossScalaVersions
-export CI_RELEASE="$projectPrefix/publishSigned"
-export CI_SNAPSHOT_RELEASE="$projectPrefix/publish"
+export CI_RELEASE="${projectPrefix}publishSigned"
+export CI_SNAPSHOT_RELEASE="${projectPrefix}publish"
 
 # default is sonatypeBundleRelease, which closes and releases the staging repo
 # see https://github.com/xerial/sbt-sonatype#commands
 # for now, until we're confident in the new release scripts, just close the staging repo.
 export CI_SONATYPE_RELEASE="; sonatypePrepare; sonatypeBundleUpload; sonatypeClose"
 
-sbt clean $projectPrefix/test $projectPrefix/publishLocal $releaseTask
+sbt clean ${projectPrefix}test ${projectPrefix}publishLocal $releaseTask

--- a/shared/src/main/scala/scala/util/parsing/combinator/JavaTokenParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/JavaTokenParsers.scala
@@ -14,7 +14,6 @@ package scala
 package util.parsing.combinator
 
 import scala.annotation.migration
-import scala.language.implicitConversions
 
 /** `JavaTokenParsers` differs from [[scala.util.parsing.combinator.RegexParsers]]
  *  by adding the following definitions:

--- a/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
@@ -67,11 +67,11 @@ trait PackratParsers extends Parsers {
      */
     private[PackratParsers] val cache = mutable.HashMap.empty[(Parser[_], Position), MemoEntry[_]]
 
-    private[PackratParsers] def getFromCache[T](p: Parser[T]): Option[MemoEntry[T]] = {
-      cache.get((p, pos)).asInstanceOf[Option[MemoEntry[T]]]
+    private[PackratParsers] def getFromCache[T2](p: Parser[T2]): Option[MemoEntry[T2]] = {
+      cache.get((p, pos)).asInstanceOf[Option[MemoEntry[T2]]]
     }
 
-    private[PackratParsers] def updateCacheAndGet[T](p: Parser[T], w: MemoEntry[T]): MemoEntry[T] = {
+    private[PackratParsers] def updateCacheAndGet[T2](p: Parser[T2], w: MemoEntry[T2]): MemoEntry[T2] = {
       cache.put((p, pos),w)
       w
     }

--- a/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
@@ -238,7 +238,7 @@ trait Parsers {
       = withFilter(p)
 
     def withFilter(p: T => Boolean): Parser[T]
-      = Parser{ in => this(in) filterWithError(p, "Input doesn't match filter: "+_, in)}
+      = Parser{ in => this(in).filterWithError(p, "Input doesn't match filter: "+_, in)}
 
     // no filter yet, dealing with zero is tricky!
 

--- a/shared/src/main/scala/scala/util/parsing/combinator/lexical/StdLexical.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/lexical/StdLexical.scala
@@ -18,7 +18,6 @@ package lexical
 import token._
 import input.CharArrayReader.EofCh
 import scala.collection.mutable
-import scala.language.implicitConversions
 
 /** This component provides a standard lexical parser for a simple,
  *  [[http://scala-lang.org Scala]]-like language. It parses keywords and


### PR DESCRIPTION
the commits are probably easier to review individually

note that the build.sh changes enable publishing on Dotty — I don't know why that was disabled before, perhaps inadvertent/historical? if there's some problem, I guess we'll find out when we roll 1.2.0 (whenever that is)