### PR TITLE
remove author tags from Scaladoc

### DIFF
--- a/jvm/src/main/scala/scala/util/parsing/input/PositionCache.scala
+++ b/jvm/src/main/scala/scala/util/parsing/input/PositionCache.scala
@@ -12,9 +12,6 @@
 
 package scala.util.parsing.input
 
-/**
- * @author Tomáš Janoušek
- */
 private[input] trait PositionCache {
   private lazy val indexCacheTL =
     // not DynamicVariable as that would share the map from parent to child :-(

--- a/shared/src/main/scala/scala/util/parsing/combinator/ImplicitConversions.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/ImplicitConversions.scala
@@ -27,10 +27,6 @@ import scala.language.implicitConversions
  * The `headOptionTailToFunList` converts a function that takes a `List[A]` to a function that
  * accepts a `~[A, Option[List[A]]]` (this happens when parsing something of the following
  * shape: `p ~ opt("." ~ repsep(p, "."))` -- where `p` is a parser that yields an `A`).
- *
- * @author Martin Odersky
- * @author Iulian Dragos
- * @author Adriaan Moors
  */
 trait ImplicitConversions { self: Parsers =>
   implicit def flatten2[A, B, C]         (f: (A, B) => C): A ~ B => C =

--- a/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
@@ -51,8 +51,6 @@ import scala.language.implicitConversions
  * @see Alessandro Warth, James R. Douglass, Todd Millstein: "Packrat Parsers Can Support Left Recursion." PEPM'08
  *
  * @since 2.8
- * @author Manohar Jonnalagedda
- * @author Tiark Rompf
  */
 
 trait PackratParsers extends Parsers {

--- a/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
@@ -72,10 +72,6 @@ import scala.language.implicitConversions
  *  methods `success`, `err` and `failure` as examples.
  *
  *  @see [[scala.util.parsing.combinator.RegexParsers]] and other known subclasses for practical examples.
- *
- *  @author Martin Odersky
- *  @author Iulian Dragos
- *  @author Adriaan Moors
  */
 trait Parsers {
   /** the type of input elements the provided parsers consume (When consuming

--- a/shared/src/main/scala/scala/util/parsing/combinator/lexical/Lexical.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/lexical/Lexical.scala
@@ -23,8 +23,6 @@ import input.CharArrayReader.EofCh
  *
  *  Refer to [[scala.util.parsing.combinator.lexical.StdLexical]]
  *  for a concrete implementation for a simple, Scala-like language.
- *
- * @author Martin Odersky, Adriaan Moors
  */
 abstract class Lexical extends Scanners with Tokens {
 

--- a/shared/src/main/scala/scala/util/parsing/combinator/lexical/Scanners.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/lexical/Scanners.scala
@@ -21,8 +21,6 @@ import input._
  *
  *  See its subclasses [[scala.util.parsing.combinator.lexical.Lexical]] and -- most interestingly
  *  [[scala.util.parsing.combinator.lexical.StdLexical]], for more functionality.
- *
- *  @author Martin Odersky, Adriaan Moors
  */
 trait Scanners extends Parsers {
   type Elem = Char

--- a/shared/src/main/scala/scala/util/parsing/combinator/lexical/StdLexical.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/lexical/StdLexical.scala
@@ -32,10 +32,6 @@ import scala.collection.mutable
  *  Usually this component is used to break character-based input into
  *  bigger tokens, which are then passed to a token-parser (see
  *  [[scala.util.parsing.combinator.syntactical.TokenParsers]].)
- *
- * @author Martin Odersky
- * @author Iulian Dragos
- * @author Adriaan Moors
  */
 class StdLexical extends Lexical with StdTokens {
   // see `token` in `Scanners`

--- a/shared/src/main/scala/scala/util/parsing/combinator/syntactical/StandardTokenParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/syntactical/StandardTokenParsers.scala
@@ -20,8 +20,6 @@ import lexical.StdLexical
 import scala.language.implicitConversions
 
 /** This component provides primitive parsers for the standard tokens defined in `StdTokens`.
-*
-* @author Martin Odersky, Adriaan Moors
  */
 class StandardTokenParsers extends StdTokenParsers {
   type Tokens = StdTokens

--- a/shared/src/main/scala/scala/util/parsing/combinator/syntactical/StdTokenParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/syntactical/StdTokenParsers.scala
@@ -20,8 +20,6 @@ import scala.collection.mutable
 import scala.language.implicitConversions
 
 /** This component provides primitive parsers for the standard tokens defined in `StdTokens`.
-*
-* @author Martin Odersky, Adriaan Moors
  */
 trait StdTokenParsers extends TokenParsers {
   type Tokens <: StdTokens

--- a/shared/src/main/scala/scala/util/parsing/combinator/syntactical/TokenParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/syntactical/TokenParsers.scala
@@ -16,9 +16,6 @@ package combinator
 package syntactical
 
 /** This is the core component for token-based parsers.
- *
- *  @author Martin Odersky
- *  @author Adriaan Moors
  */
 trait TokenParsers extends Parsers {
   /** `Tokens` is the abstract type of the `Token`s consumed by the parsers in this component. */

--- a/shared/src/main/scala/scala/util/parsing/combinator/token/StdTokens.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/token/StdTokens.scala
@@ -16,9 +16,6 @@ package combinator
 package token
 
 /** This component provides the standard `Token`s for a simple, Scala-like language.
- *
- * @author Martin Odersky
- * @author Adriaan Moors
  */
 trait StdTokens extends Tokens {
   /** The class of keyword tokens */

--- a/shared/src/main/scala/scala/util/parsing/combinator/token/Tokens.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/token/Tokens.scala
@@ -17,9 +17,6 @@ package token
 
 /** This component provides the notion of `Token`, the unit of information that is passed from lexical
  * parsers in the `Lexical` component to the parsers in the `TokenParsers` component.
- *
- * @author Martin Odersky
- * @author Adriaan Moors
  */
 trait Tokens {
   /** Objects of this type are produced by a lexical parser or ``scanner``, and consumed by a parser.

--- a/shared/src/main/scala/scala/util/parsing/input/CharArrayReader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/CharArrayReader.scala
@@ -14,9 +14,6 @@ package scala
 package util.parsing.input
 
 /** An object encapsulating basic character constants.
- *
- * @author Martin Odersky
- * @author Adriaan Moors
  */
 object CharArrayReader {
   final val EofCh = '\u001a'
@@ -27,9 +24,6 @@ object CharArrayReader {
  *
  * @param chars  an array of characters
  * @param index  starting offset into the array; the first element returned will be `source(index)`
- *
- * @author Martin Odersky
- * @author Adriaan Moors
  */
 class CharArrayReader(chars: Array[Char], index: Int = 0)
     extends CharSequenceReader(java.nio.CharBuffer.wrap(chars), index)

--- a/shared/src/main/scala/scala/util/parsing/input/CharSequenceReader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/CharSequenceReader.scala
@@ -14,8 +14,6 @@ package scala
 package util.parsing.input
 
 /** An object encapsulating basic character constants.
- *
- * @author Martin Odersky, Adriaan Moors
  */
 object CharSequenceReader {
   final val EofCh = '\u001a'
@@ -26,8 +24,6 @@ object CharSequenceReader {
  *
  * @param source the source sequence
  * @param offset  starting offset.
- *
- * @author Martin Odersky
  */
 class CharSequenceReader(override val source: java.lang.CharSequence,
                          override val offset: Int) extends Reader[Char] {

--- a/shared/src/main/scala/scala/util/parsing/input/NoPosition.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/NoPosition.scala
@@ -14,9 +14,6 @@ package scala
 package util.parsing.input
 
 /** Undefined position.
- *
- * @author Martin Odersky
- * @author Adriaan Moors
  */
 object NoPosition extends Position {
   def line = 0

--- a/shared/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
@@ -20,8 +20,6 @@ import scala.collection.mutable.ArrayBuffer
  *
  *   @param source   The source document
  *   @param offset   The offset indicating the position
- *
- * @author Martin Odersky
  */
 case class OffsetPosition(source: CharSequence, offset: Int) extends Position {
 

--- a/shared/src/main/scala/scala/util/parsing/input/PagedSeq.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/PagedSeq.scala
@@ -105,7 +105,6 @@ import PagedSeq._
  *
  *  @tparam T     the type of the elements contained in this paged sequence, with an `ClassTag` context bound.
  *
- *  @author Martin Odersky
  *  @define Coll `PagedSeq`
  *  @define coll paged sequence
  *  @define mayNotTerminateInf

--- a/shared/src/main/scala/scala/util/parsing/input/PagedSeqReader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/PagedSeqReader.scala
@@ -14,9 +14,6 @@ package scala
 package util.parsing.input
 
 /** An object encapsulating basic character constants.
- *
- * @author Martin Odersky
- * @author Adriaan Moors
  */
 object PagedSeqReader {
   final val EofCh = '\u001a'
@@ -27,8 +24,6 @@ object PagedSeqReader {
  *
  * @param seq     the source sequence
  * @param offset  starting offset.
- *
- * @author Martin Odersky
  */
 class PagedSeqReader(seq: PagedSeq[Char],
                      override val offset: Int) extends Reader[Char] { outer =>

--- a/shared/src/main/scala/scala/util/parsing/input/Position.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/Position.scala
@@ -20,9 +20,6 @@ package util.parsing.input
  *   - comparing two positions (`<`).
  *
  *  To use this class for a concrete kind of `document`, implement the `lineContents` method.
- *
- * @author Martin Odersky
- * @author Adriaan Moors
  */
 trait Position {
 

--- a/shared/src/main/scala/scala/util/parsing/input/Positional.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/Positional.scala
@@ -14,8 +14,6 @@ package scala
 package util.parsing.input
 
 /** A trait for objects that have a source position.
- *
- * @author Martin Odersky, Adriaan Moors
  */
 trait Positional {
 

--- a/shared/src/main/scala/scala/util/parsing/input/Reader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/Reader.scala
@@ -15,9 +15,6 @@ package util.parsing.input
 
 
 /** An interface for streams of values that have positions.
- *
- * @author Martin Odersky
- * @author Adriaan Moors
  */
 abstract class Reader[+T] {
 

--- a/shared/src/main/scala/scala/util/parsing/input/StreamReader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/StreamReader.scala
@@ -14,8 +14,6 @@ package scala
 package util.parsing.input
 
 /** An object to create a `StreamReader` from a `java.io.Reader`.
- *
- * @author Miles Sabin
  */
 object StreamReader {
   final val EofCh = '\u001a'
@@ -42,9 +40,6 @@ object StreamReader {
  *
  *  If you need to match regexes spanning several lines you should consider
  *  class `PagedSeqReader` instead.
- *
- *  @author Miles Sabin
- *  @author Martin Odersky
  */
 sealed class StreamReader private (seq: PagedSeq[Char], off: Int, lnum: Int, nextEol0: Int) extends PagedSeqReader(seq, off) {
   def this(seq: PagedSeq[Char], off: Int, lnum: Int) = this(seq, off, lnum, -1)


### PR DESCRIPTION
It's noise. We did the same thing in the Scala standard library sources a while ago.

Archaeologists may consult the version control history.