### PR TITLE
adjust the lastFailure change to be source compatible

### DIFF
--- a/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
@@ -132,8 +132,8 @@ trait Parsers {
    *  @param result The parser's output
    *  @param next   The parser's remaining input
    */
-  abstract case class Success[+T](result: T, override val next: Input) extends ParseResult[T] {
-    val lastFailure: Option[Failure]
+  case class Success[+T](result: T, override val next: Input) extends ParseResult[T] {
+    def lastFailure: Option[Failure] = None
 
     def map[U](f: T => U) = Success(f(result), next, lastFailure)
 


### PR DESCRIPTION
sequel to #234 

in the community build I saw this compile error:

```
[playframework] [error] /home/jenkins/workspace/scala-2.13.x-jdk11-integrate-community-build/target-0.9.17/project-builds/playframework-09235f39491e975fec63cc899de593c88cef0cc0/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala:167:38: RoutesFileParser.this.Success.type does not take parameters
[playframework] [error]         case Failure(_, _) => Success(elems.toList, in0)
[playframework] [error]                                      ^
```