### PR TITLE
Scala 3: Sonatype won't let us publish without a doc jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,12 +41,9 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
       )
       case _ => Seq()
     }),
-    // don't run Dottydoc, it errors and isn't needed anyway
-    Compile / doc / sources := (if (isDotty.value) Seq() else (Compile / doc/ sources).value),
-    Compile / packageDoc / publishArtifact := !isDotty.value,
     Compile / doc / scalacOptions ++= {
       if (isDotty.value)
-        Seq()
+        Seq()  // TODO see what flags might be desirable to pass to Scala3doc
       else
         Seq(
           "-diagrams",


### PR DESCRIPTION
this came up over at #334 

https://travis-ci.com/github/scala/scala-parser-combinators/jobs/463091158

```
2020-12-20 01:18:17.426Z  info [SonatypeClient]     Failed: javadoc-staging, failureMessage:Missing: no javadoc jar found in folder '/org/scala-lang/modules/scala-parser-combinators_sjs1_3.0.0-M3/1.2.0-M1'  - (SonatypeClient.scala:356)
```