### PR TITLE
Update nscplugin, sbt-scala-native to 0.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,11 @@ env:
 matrix:
   include:
     - scala: 2.11.12
-      env: ADOPTOPENJDK=8     SCALANATIVE_VERSION=0.3.9
-    - scala: 2.11.12
-      env: ADOPTOPENJDK=8     SCALANATIVE_VERSION=0.4.0-M2
+      env: ADOPTOPENJDK=8     SCALANATIVE_VERSION=0.4.0
+    - scala: 2.12.13
+      env: ADOPTOPENJDK=8     SCALANATIVE_VERSION=0.4.0
+    - scala: 2.13.4
+      env: ADOPTOPENJDK=8     SCALANATIVE_VERSION=0.4.0
 
 install:
   - git fetch --tags # get all tags for sbt-dynver

--- a/build.sbt
+++ b/build.sbt
@@ -83,10 +83,10 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
   )
   .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
   .nativeSettings(
-    compile / skip := System.getProperty("java.version").startsWith("1.6") || !scalaVersion.value.startsWith("2.11"),
+    compile / skip := System.getProperty("java.version").startsWith("1.6") || !scalaVersion.value.startsWith("3"),
     test := {},
     libraryDependencies := {
-      if (!scalaVersion.value.startsWith("2.11"))
+      if (!scalaVersion.value.startsWith("3"))
         libraryDependencies.value.filterNot(_.organization == "org.scala-native")
       else libraryDependencies.value
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ val scalaJSVersion =
   Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("1.4.0")
 
 val scalaNativeVersion =
-  Option(System.getenv("SCALANATIVE_VERSION")).filter(_.nonEmpty).getOrElse("0.3.9")
+  Option(System.getenv("SCALANATIVE_VERSION")).filter(_.nonEmpty).getOrElse("0.4.0")
 
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "2.2.3")
 


### PR DESCRIPTION
Applying this PR will update Scala native to 0.4.0, dropping 0.3.9 and 0.4.0-M2. Added scala 2.12 and 2.13 to the build matrix for Scala native as those are supported now. Closes #346.