### PR TITLE
PackratParsers#phrase: explicit return type (fixes #369)

### DIFF
--- a/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
@@ -101,7 +101,7 @@ trait PackratParsers extends Parsers {
    *  Overridden to make sure any input passed to the argument parser
    *  is wrapped in a `PackratReader`.
    */
-  override def phrase[T](p: Parser[T]) = {
+  override def phrase[T](p: Parser[T]): PackratParser[T] = {
     val q = super.phrase(p)
     new PackratParser[T] {
       def apply(in: Input) = in match {


### PR DESCRIPTION
This fixes #369.

*TL;DR* A missed result type for `PackratParsers#phrase` results in a different behaviour (Scala 2.x. vs Scala 3.x) for edgy cases.

Long explanation:

It seems (I was not able to quickly find a corresponding reference) that in Scala 3.0 if an overriding method doesn't explicitly specify the result type, the result type of the base method is taken (even if the compiler can figure out a more concrete type).

This leads to a corner case with PackratParsers#phrase, which in 2.x has the effective/inferred type `def phrase[T](p: Parser[T]): PackratParser[T]` and in 3.x has the effective/inferred type `def phrase[T](p: Parser[T]): Parser[T]`.

This results into an extra implicit conversion `parser2packrat` being inserted even if the current parser is already a Packrat Parser. This, in turn, breaks assumptions of the `memo` method.

---

Providing explicit return type fixes #369 subtlety.
- A corresponding test case was added.

---

The added test is OK for Scala 2.x, but fails for Scala 3.x - as can be seen from this run - https://github.com/ilya-klyuchnikov/scala-parser-combinators/commit/92a338ea19567614d30b1f6f1b8b7953849779a5.
Correspondingly, after the fix, the test is OK for both Scala 2.x and Scala 3.x

---
I have been bitten by this subtlety - while migrating https://github.com/ilya-klyuchnikov/tapl-scala to Scala 3.