### PR TITLE
Fix compile/skip and libraryDependencies for scala native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,7 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
   )
   .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
   .nativeSettings(
+    scalaModuleMimaPreviousVersion := None, // https://github.com/scala/scala-parser-combinators/pull/381
     compile / skip := System.getProperty("java.version").startsWith("1.6") || !scalaVersion.value.startsWith("2"),
     test := {},
     libraryDependencies := {

--- a/build.sbt
+++ b/build.sbt
@@ -89,10 +89,10 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
   )
   .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
   .nativeSettings(
-    compile / skip := System.getProperty("java.version").startsWith("1.6") || !scalaVersion.value.startsWith("3"),
+    compile / skip := System.getProperty("java.version").startsWith("1.6") || !scalaVersion.value.startsWith("2"),
     test := {},
     libraryDependencies := {
-      if (!scalaVersion.value.startsWith("3"))
+      if (!scalaVersion.value.startsWith("2"))
         libraryDependencies.value.filterNot(_.organization == "org.scala-native")
       else libraryDependencies.value
     }


### PR DESCRIPTION
Applying this PR will fix the `compile / skip`- and `libraryDependencies`-settings for scala native. Seems I got some if-statements wrong in https://github.com/scala/scala-parser-combinators/pull/347. After this is merged we should have non-empty jars again for scala native, see https://github.com/scala/scala-parser-combinators/issues/380.