### PR TITLE
StdLexical now emits one ErrorToken for unclosed comments.

### DIFF
--- a/shared/src/main/scala/scala/util/parsing/combinator/lexical/StdLexical.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/lexical/StdLexical.scala
@@ -58,7 +58,7 @@ class StdLexical extends Lexical with StdTokens {
       whitespaceChar
     | '/' ~ '*' ~ comment
     | '/' ~ '/' ~ rep( chrExcept(EofCh, '\n') )
-    | '/' ~ '*' ~ failure("unclosed comment")
+    | '/' ~ '*' ~ rep( elem("", _ => true) ) ~> err("unclosed comment")
     )
 
   protected def comment: Parser[Any] = (

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh56.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh56.scala
@@ -25,12 +25,12 @@ class gh56 {
       """/* an unclosed comment
         |of multiple lines
         |just to check longString/lineContents
-      """.stripMargin
+        |""".stripMargin
 
     val fail =
-      """[1.1] failure: identifier expected
+      """[4.1] failure: identifier expected
         |
-        |/* an unclosed comment
+        |
         |^""".stripMargin
 
     val parseResult = phrase(term)(new lexical.Scanner(expr))
@@ -46,10 +46,10 @@ class gh56 {
     val expr = "/* an unclosed comment without newline"
 
     val fail =
-      """[1.1] failure: identifier expected
+      """[1.39] failure: identifier expected
         |
         |/* an unclosed comment without newline
-        |^""".stripMargin
+        |                                      ^""".stripMargin
 
     val parseResult = phrase(term)(new lexical.Scanner(expr))
     assertTrue(parseResult.isInstanceOf[Failure])

--- a/shared/src/test/scala/scala/util/parsing/combinator/lexical/StdLexicalTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/lexical/StdLexicalTest.scala
@@ -6,7 +6,6 @@ import org.junit.Assert.assertEquals
 import scala.util.parsing.input.Reader
 
 import scala.collection.mutable.ListBuffer
-import java.awt.RenderingHints.Key
 
 class StdLexicalTest {
   private def lex[Lexer <: StdLexical](lexer: Lexer, input: String): List[lexer.Token] = {
@@ -121,6 +120,22 @@ class StdLexicalTest {
     assertEquals(
       List(Identifier("id1"), Identifier("id2")),
       lex(Lexer, "/* single */ id1 /* multi \n line */ id2")
+    )
+  }
+
+  @Test
+  def parseUnclosedComments: Unit = {
+    object Lexer extends StdLexical
+    import Lexer._
+
+    assertEquals(
+      List(Identifier("id"), ErrorToken("unclosed comment")),
+      lex(Lexer, "id /*")
+    )
+
+    assertEquals(
+      List(Identifier("id"), ErrorToken("unclosed comment")),
+      lex(Lexer, "id /* ")
     )
   }
 }


### PR DESCRIPTION
Fixes issue #399