### PR TITLE
A proposed new interface for skipping characters automatically

### DIFF
--- a/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
@@ -104,7 +104,7 @@ trait PackratParsers extends Parsers {
   override def phrase[T](p: Parser[T]): PackratParser[T] = {
     val q = super.phrase(p)
     new PackratParser[T] {
-      def apply(in: Input) = in match {
+      def parse(in: Input) = in match {
         case in: PackratReader[_] => q(in)
         case in => q(new PackratReader(in))
       }
@@ -231,7 +231,7 @@ to update each parser involved in the recursion.
    */
   def memo[T](p: super.Parser[T]): PackratParser[T] = {
     new PackratParser[T] {
-      def apply(in: Input) = {
+      def parse(in: Input) = {
         /*
          * transformed reader
          */

--- a/shared/src/main/scala/scala/util/parsing/combinator/RegexParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/RegexParsers.scala
@@ -48,7 +48,7 @@ import scala.language.implicitConversions
  *      }
  *    }
  *
- *    def apply(input: String): Double = parseAll(expr, input) match {
+ *    def parse(input: String): Double = parseAll(expr, input) match {
  *      case Success(result, _) => result
  *      case failure : NoSuccess => scala.sys.error(failure.msg)
  *    }
@@ -83,7 +83,7 @@ trait RegexParsers extends Parsers {
 
   /** A parser that matches a literal string */
   implicit def literal(s: String): Parser[String] = new Parser[String] {
-    def apply(in: Input) = {
+    def parse(in: Input) = {
       val source = in.source
       val offset = in.offset
       val start = handleWhiteSpace(source, offset)
@@ -104,7 +104,7 @@ trait RegexParsers extends Parsers {
 
   /** A parser that matches a regex string */
   implicit def regex(r: Regex): Parser[String] = new Parser[String] {
-    def apply(in: Input) = {
+    def parse(in: Input) = {
       val source = in.source
       val offset = in.offset
       val start = handleWhiteSpace(source, offset)
@@ -131,7 +131,7 @@ trait RegexParsers extends Parsers {
   override def positioned[T <: Positional](p: => Parser[T]): Parser[T] = {
     val pp = super.positioned(p)
     new Parser[T] {
-      def apply(in: Input) = {
+      def parse(in: Input) = {
         val offset = in.offset
         val start = handleWhiteSpace(in.source, offset)
         pp(in.drop (start - offset))
@@ -141,7 +141,7 @@ trait RegexParsers extends Parsers {
 
   // we might want to make it public/protected in a future version
   private def ws[T](p: Parser[T]): Parser[T] = new Parser[T] {
-    def apply(in: Input) = {
+    def parse(in: Input) = {
       val offset = in.offset
       val start = handleWhiteSpace(in.source, offset)
       p(in.drop (start - offset))

--- a/shared/src/main/scala/scala/util/parsing/combinator/lexical/Scanners.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/lexical/Scanners.scala
@@ -32,9 +32,6 @@ trait Scanners extends Parsers {
   /** A parser that produces a token (from a stream of characters). */
   def token: Parser[Token]
 
-  /** A parser for white-space -- its result will be discarded. */
-  def whitespace: Parser[Any]
-
   /** `Scanner` is essentially¹ a parser that produces `Token`s
    *  from a stream of characters. The tokens it produces are typically
    *  passed to parsers in `TokenParsers`.
@@ -44,21 +41,18 @@ trait Scanners extends Parsers {
   class Scanner(in: Reader[Char]) extends Reader[Token] {
     /** Convenience constructor (makes a character reader out of the given string) */
     def this(in: String) = this(new CharArrayReader(in.toCharArray))
-    private val (tok, rest1, rest2) = whitespace(in) match {
-      case Success(_, in1) =>
-        token(in1) match {
-          case Success(tok, in2) => (tok, in1, in2)
-          case ns: NoSuccess => (errorToken(ns.msg), ns.next, skip(ns.next))
-        }
-      case ns: NoSuccess => (errorToken(ns.msg), ns.next, skip(ns.next))
+    private val in1 = skip(in)
+    private val (tok, rest1, rest2) = token(in1) match {
+      case Success(tok, in2) => (tok, in1, in2)
+      case ns: NoSuccess => (errorToken(ns.msg), ns.next, skipChar(ns.next))
     }
-    private def skip(in: Reader[Char]) = if (in.atEnd) in else in.rest
+    private def skipChar(in: Reader[Char]) = if (in.atEnd) in else in.rest
 
     override def source: java.lang.CharSequence = in.source
     override def offset: Int = in.offset
     def first = tok
     def rest = new Scanner(rest2)
     def pos = rest1.pos
-    def atEnd = in.atEnd || (whitespace(in) match { case Success(_, in1) => in1.atEnd case _ => false })
+    def atEnd = in.atEnd || skip(in).atEnd
   }
 }


### PR DESCRIPTION
I implemented this new interface for Scanners but haven't yet implemented it for RegexParsers; implementing it in the obvious way for RegexParsers would create performance issues (likely making a linear process quadratic). Instead, I've pushed this to start a discussion about whether this interface is something the maintainers would like to see implemented.

The term whitespace is being used somewhat generously here; comments are not whitespace but are skipped, just as whitespace is. I renamed the `apply` method to `parse` so that `apply` could be called as before but that the desired skipping behavior would occur throughout. This has the added benefit of adding explicit meaning to the `parse` method, which subclasses will implement.

This PR begins to address https://github.com/scala/scala-parser-combinators/issues/320 and https://github.com/scala/scala-parser-combinators/issues/25