### PR TITLE
use new sbt 1.7 feature to not repeat Scala version numbers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [8, 11, 17]
-        scala: [2.11.12, 2.12.15, 2.13.8, 3.1.2]
+        scala: [2.11.x, 2.12.x, 2.13.x, 3.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
     name := "scala-parser-combinators",
     scalaModuleAutomaticModuleName := Some("scala.util.parsing"),
 
-    crossScalaVersions := Seq("2.13.8", "2.12.15", "2.11.12", "3.1.2"),
+    crossScalaVersions := Seq("2.13.8", "2.12.16", "2.11.12", "3.1.2"),
     scalaVersion := crossScalaVersions.value.head,
 
     libraryDependencies += "junit" % "junit" % "4.13.2" % Test,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.0-RC1


### PR DESCRIPTION
while we're waiting for the public Scala Steward instance to return and start sending us version bumps, I thought I'd make this PR as a way of trying out sbt 1.7's support for writing e.g. "2.12.x" in your GitHub Actions config instead of having to repeat what your `crossScalaVersions` in your `build.sbt` already says