### PR TITLE
scala-collection-compat 2.8.0 (was 2.7.0)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
     libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
     // so we can `@nowarn` in test code, but only in test code, so the dependency
     // doesn't leak downstream. can be dropped when we drop 2.11 from the crossbuild
-    libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "2.7.0" % Test,
+    libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.0" % Test,
 
     apiMappings ++= scalaInstance.value.libraryJars.collect {
       case file if file.getName.startsWith("scala-library") && file.getName.endsWith(".jar") =>


### PR DESCRIPTION
(not waiting for the steward, since I want to do a spot check that the 2.8.0 release was successful)