### PR TITLE
re-enable versionPolicy checking on Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,7 @@ ThisBuild / startYear := Some(2004)
 // I thought we could declare these in `ThisBuild` scope but no :-/
 val commonSettings = Seq(
   versionScheme := Some("early-semver"),
-  versionPolicyIntention := {
-    if (scalaVersion.value.startsWith("3"))
-      Compatibility.None
-    else
-      Compatibility.BinaryCompatible
-    }
+  versionPolicyIntention := Compatibility.BinaryCompatible,
 )
 
 lazy val root = project.in(file("."))


### PR DESCRIPTION
I think we disabled this back when we didn't have any previous Scala 3 artifacts to check against?