### PR TITLE
lock down bidirectional compat, post-2.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ ThisBuild / startYear := Some(2004)
 // I thought we could declare these in `ThisBuild` scope but no :-/
 val commonSettings = Seq(
   versionScheme := Some("early-semver"),
-  versionPolicyIntention := Compatibility.BinaryCompatible,
+  versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
 )
 
 lazy val root = project.in(file("."))


### PR DESCRIPTION
this is so we don't inadvertently make a change necessitating a minor release

~this won't pass CI until 2.2.0 is actually on Maven Central~