### PR TITLE
enable unused warnings on Scala 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
 
     // go nearly warning-free, but only on 2.13, it's too hard across all versions
     Compile / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 13)) => Seq("-Werror",
+      case Some((2, 13)) => Seq("-Werror", "-Wunused",
         // ideally we'd do something about this. `^?` is the responsible method
         "-Wconf:site=scala.util.parsing.combinator.Parsers.*&cat=lint-multiarg-infix:i",
         // not sure what resolving this would look like? didn't think about it too hard

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,14 @@
 ThisBuild / licenses += (("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0")))
 ThisBuild / startYear := Some(2004)
 
-// I thought we could declare these in `ThisBuild` scope but no :-/
 val commonSettings = Seq(
   versionScheme := Some("early-semver"),
   // next version will bump minor (because we dropped Scala 2.11 and upgraded
   // Scala.js and Scala Native); we could go back to BinaryAndSourceCompatible
   // once that's done
   versionPolicyIntention := Compatibility.BinaryCompatible,
+  crossScalaVersions := Seq("2.13.10", "2.12.17", "3.2.2"),
+  scalaVersion := crossScalaVersions.value.head,
 )
 
 lazy val root = project.in(file("."))
@@ -24,9 +25,6 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
     commonSettings,
     name := "scala-parser-combinators",
     scalaModuleAutomaticModuleName := Some("scala.util.parsing"),
-
-    crossScalaVersions := Seq("2.13.10", "2.12.17", "3.2.2"),
-    scalaVersion := crossScalaVersions.value.head,
 
     libraryDependencies += "junit" % "junit" % "4.13.2" % Test,
     libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % Test,

--- a/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
@@ -208,14 +208,14 @@ to update each parser involved in the recursion.
 
   private def lrAnswer[T](p: Parser[T], in: PackratReader[Elem], growable: LR): ParseResult[T] = growable match {
     //growable will always be having a head, we can't enter lrAnswer otherwise
-    case LR(seed ,rule, Some(head)) =>
+    case LR(seed, _, Some(head)) =>
       if(head.getHead != p) /*not head rule, so not growing*/ seed.asInstanceOf[ParseResult[T]]
       else {
         in.updateCacheAndGet(p, MemoEntry(Right(seed.asInstanceOf[ParseResult[T]])))
         seed match {
           case f@Failure(_,_) => f
           case e@Error(_,_) => e
-          case s@Success(_,_) => /*growing*/ grow(p, in, head)
+          case Success(_,_) => /*growing*/ grow(p, in, head)
         }
       }
     case _=> throw new Exception("lrAnswer with no head !!")
@@ -256,7 +256,7 @@ to update each parser involved in the recursion.
                 /*simple result*/
                 inMem.updateCacheAndGet(p,MemoEntry(Right(tempRes)))
                 tempRes
-              case s@Some(_) =>
+              case Some(_) =>
                 /*non simple result*/
                 base.seed = tempRes
                 //the base variable has passed equality tests with the cache
@@ -303,7 +303,7 @@ to update each parser involved in the recursion.
             case _ => throw new Exception("impossible match")
           }
         }
-      case f =>
+      case _ =>
         rest.recursionHeads -= rest.pos
         /*rest.updateCacheAndGet(p, MemoEntry(Right(f)));*/oldRes
     }

--- a/shared/src/main/scala/scala/util/parsing/combinator/lexical/StdLexical.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/lexical/StdLexical.scala
@@ -79,7 +79,7 @@ class StdLexical extends Lexical with StdTokens {
     // construct parser for delimiters by |'ing together the parsers for the individual delimiters,
     // starting with the longest one -- otherwise a delimiter D will never be matched if there is
     // another delimiter that is a prefix of D
-    def parseDelim(s: String): Parser[Token] = accept(s.toList) ^^ { x => Keyword(s) }
+    def parseDelim(s: String): Parser[Token] = accept(s.toList) ^^ { _ => Keyword(s) }
 
     val d = new Array[String](delimiters.size)
     delimiters.copyToArray(d, 0)

--- a/shared/src/test/scala/scala/util/parsing/combinator/JavaTokenParsersTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/JavaTokenParsersTest.scala
@@ -12,7 +12,6 @@
 
 package scala.util.parsing.combinator
 
-import scala.language.implicitConversions
 import scala.util.parsing.input.CharArrayReader
 
 import org.junit.Test
@@ -46,7 +45,7 @@ class JavaTokenParsersTest {
     def parseFailure(s: String, errorColPos: Int): Unit = {
       val parseResult = parseAll(ident, s)
       parseResult match {
-        case Failure(msg, next) =>
+        case Failure(_, next) =>
           val pos = next.pos
           assertEquals(1, pos.line)
           assertEquals(errorColPos, pos.column)
@@ -85,7 +84,7 @@ class JavaTokenParsersTest {
 
     val parseResult1 = parseAll(p, "start start")
     parseResult1 match {
-      case e @ Failure(message, next) =>
+      case Failure(message, next) =>
         assertEquals(next.pos.line, 1)
         assertEquals(next.pos.column, 7)
         assert(message.endsWith("string matching regex '(?i)AND' expected but 's' found"))

--- a/shared/src/test/scala/scala/util/parsing/combinator/PackratParsersTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/PackratParsersTest.scala
@@ -16,7 +16,6 @@ import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 
-import scala.language.implicitConversions
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
 
 class PackratParsersTest {

--- a/shared/src/test/scala/scala/util/parsing/combinator/RegexParsersTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/RegexParsersTest.scala
@@ -12,8 +12,6 @@
 
 package scala.util.parsing.combinator
 
-import scala.language.implicitConversions
-
 import org.junit.Test
 import org.junit.Assert.{ assertEquals, assertTrue }
 
@@ -63,10 +61,10 @@ class RegexParsersTest {
       def halfQuoted = quote ~ string ^^ { case q ~ s => q + s }
     }
     import parser._
-    val failureLq = parseAll(p, "\"asdf").asInstanceOf[Failure]
-    val failureRq = parseAll(p, "asdf\"").asInstanceOf[Failure]
-    val failureQBacktrackL = parseAll(q | quote, "\"").asInstanceOf[Error]
-    val failureQBacktrackR = parseAll(q | halfQuoted, "\"asdf").asInstanceOf[Error]
+    assertTrue(parseAll(p, "\"asdf").isInstanceOf[Failure])
+    assertTrue(parseAll(p, "asdf\"").isInstanceOf[Failure])
+    assertTrue(parseAll(q | quote, "\"").isInstanceOf[Error])
+    assertTrue(parseAll(q | halfQuoted, "\"asdf").isInstanceOf[Error])
 
     val successP = parseAll(p, "\"asdf\"").get
     assertEquals(successP, "asdf")

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh242.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh242.scala
@@ -13,7 +13,6 @@
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-import scala.language.implicitConversions
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.CharSequenceReader
 

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh29.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh29.scala
@@ -14,7 +14,6 @@ package scala.util.parsing.combinator
 
 import org.junit.Test
 import org.junit.Assert.assertEquals
-import scala.language.implicitConversions
 
 class gh29 {
   object Foo extends JavaTokenParsers {

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh45.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh45.scala
@@ -12,7 +12,6 @@
 
 package scala.util.parsing.combinator
 
-import scala.language.implicitConversions
 import scala.util.parsing.input._
 
 import org.junit.Test

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh72.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh72.scala
@@ -10,7 +10,6 @@
  * additional information regarding copyright ownership.
  */
 
-import scala.language.implicitConversions
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.CharSequenceReader
 

--- a/shared/src/test/scala/scala/util/parsing/combinator/t0700.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t0700.scala
@@ -10,9 +10,8 @@
  * additional information regarding copyright ownership.
  */
 
-import java.io.{File,StringReader}
+import java.io.StringReader
 
-import scala.language.implicitConversions
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.{CharArrayReader, StreamReader}
 

--- a/shared/src/test/scala/scala/util/parsing/combinator/t1229.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t1229.scala
@@ -14,7 +14,6 @@ import scala.util.parsing.combinator.RegexParsers
 
 import org.junit.Test
 import org.junit.Assert.assertEquals
-import scala.language.implicitConversions
 
 class t1229 extends RegexParsers {
   val number = """0|[1-9]\d*""".r ^^ { _.toInt }

--- a/shared/src/test/scala/scala/util/parsing/combinator/t3212.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t3212.scala
@@ -14,7 +14,6 @@ package scala.util.parsing.combinator
 
 import org.junit.Test
 import org.junit.Assert.assertEquals
-import scala.language.implicitConversions
 
 class t3212 extends RegexParsers {
 

--- a/shared/src/test/scala/scala/util/parsing/combinator/t5514.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t5514.scala
@@ -10,7 +10,6 @@
  * additional information regarding copyright ownership.
  */
 
-import scala.language.implicitConversions
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.Reader
 import scala.util.parsing.input.Position

--- a/shared/src/test/scala/scala/util/parsing/combinator/t5669.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t5669.scala
@@ -12,7 +12,6 @@
 
 package scala.util.parsing.combinator
 
-import scala.language.implicitConversions
 import scala.util.parsing.input.OffsetPosition
 
 import org.junit.Test

--- a/shared/src/test/scala/scala/util/parsing/combinator/t6067.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t6067.scala
@@ -14,7 +14,6 @@ import scala.util.parsing.combinator._
 
 import org.junit.Test
 import org.junit.Assert.assertEquals
-import scala.language.implicitConversions
 
 class t6067 extends RegexParsers {
   object TestParser extends RegexParsers {

--- a/shared/src/test/scala/scala/util/parsing/combinator/t6464.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t6464.scala
@@ -10,7 +10,6 @@
  * additional information regarding copyright ownership.
  */
 
-import scala.language.implicitConversions
 import scala.util.parsing.input.CharSequenceReader
 import scala.util.parsing.combinator.RegexParsers
 

--- a/shared/src/test/scala/scala/util/parsing/input/OffsetPositionTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/input/OffsetPositionTest.scala
@@ -14,7 +14,6 @@ package scala.util.parsing.input
 
 import org.junit.Test
 import org.junit.Assert.assertEquals
-import scala.language.implicitConversions
 
 class OffsetPositionTest {
   @Test

--- a/shared/src/test/scala/scala/util/parsing/input/gh178.scala
+++ b/shared/src/test/scala/scala/util/parsing/input/gh178.scala
@@ -14,7 +14,6 @@ package scala.util.parsing.input
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import scala.language.implicitConversions
 
 class gh178 {
 

--- a/shared/src/test/scala/scala/util/parsing/input/gh64.scala
+++ b/shared/src/test/scala/scala/util/parsing/input/gh64.scala
@@ -14,7 +14,6 @@ package scala.util.parsing.input
 
 import org.junit.Assert._
 import org.junit.Test
-import scala.language.implicitConversions
 
 class gh64 {
 


### PR DESCRIPTION
enable unused warnings on Scala 2

I'm also interested in enabling this on Scala 3 eventually, but for now there are too many bugs (but I'm reporting them, one at a time)

also fix an annoyance by setting `crossScalaVersions` on root project. this makes `++` work

as an aside, it was nice not to have to worry about Scala 2.11, here 😊