### PR TITLE
added equality comparison for Position objects

### DIFF
--- a/shared/src/main/scala/scala/util/parsing/input/Position.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/Position.scala
@@ -60,4 +60,11 @@ trait Position {
     this.line < that.line ||
     this.line == that.line && this.column < that.column
   }
+
+  /** Compare this position to another, checking for equality.
+   *
+   * @param `that` a `Position` to compare to this `Position`
+   * @return true if the line numbers and column numbers are equal.
+   */
+  def ==(that: Position) = this.line == that.line && this.column == that.column
 }

--- a/shared/src/main/scala/scala/util/parsing/input/Position.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/Position.scala
@@ -66,5 +66,10 @@ trait Position {
    * @param `that` a `Position` to compare to this `Position`
    * @return true if the line numbers and column numbers are equal.
    */
-  def ==(that: Position) = this.line == that.line && this.column == that.column
+  override def equals(other: Any) = {
+    other match {
+      case that: Position => this.line == that.line && this.column == that.column
+      case _ => false
+    }
+  }
 }

--- a/shared/src/test/scala/scala/util/parsing/combinator/LongestMatchTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/LongestMatchTest.scala
@@ -1,0 +1,52 @@
+package scala.util.parsing.combinator
+
+import java.io.StringReader
+
+import scala.util.parsing.combinator.Parsers
+import scala.util.parsing.input.StreamReader
+
+import org.junit.Test
+import org.junit.Assert.{ assertEquals, fail }
+
+class LongestMatchTest {
+  class TestParsers extends Parsers {
+    type Elem = Char
+
+    def ab: Parser[String] = 'a' ~ 'b' ^^^ "ab"
+    def a: Parser[String] = 'a' ^^^ "a"
+    def ab_alt: Parser[String] = 'a' ~ 'b' ^^^ "alt"
+  }
+
+  @Test
+  def longestMatchFirst: Unit = {
+    val tParsers = new TestParsers
+    val reader = StreamReader(new StringReader("ab"))
+    val p = tParsers.ab ||| tParsers.a
+    p(reader) match {
+      case tParsers.Success(result, _) => assertEquals("ab", result)
+      case _ => fail()
+    }
+  }
+
+  @Test
+  def longestMatchSecond: Unit = {
+    val tParsers = new TestParsers
+    val reader = StreamReader(new StringReader("ab"))
+    val p = tParsers.a ||| tParsers.ab
+    p(reader) match {
+      case tParsers.Success(result, _) => assertEquals("ab", result)
+      case _ => fail()
+    }
+  }
+
+  @Test
+  def tieGoesToFirst: Unit = {
+    val tParsers = new TestParsers
+    val reader = StreamReader(new StringReader("ab"))
+    val p = tParsers.ab ||| tParsers.ab_alt
+    p(reader) match {
+      case tParsers.Success(result, _) => assertEquals("ab", result)
+      case _ => fail()
+    }
+  }
+}


### PR DESCRIPTION
`Parsers.Parser.|||` was not working as expected. I looked into it and discovered that `Position` objects were using pointer equality, not structural equality. I added this equality function and it fixed the issue.

I won't be offended if there are changes that need to be made to make this more idiomatic or whatever.