### PR TITLE
upgrade to Scala 3.3.0 and enable unused warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,9 @@ ThisBuild / startYear := Some(2004)
 
 val commonSettings = Seq(
   versionScheme := Some("early-semver"),
-  versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+  // change back to BinaryAndSourceCompatible after next minor release;
+  // the Scala 3.2 -> 3.3 upgrade requires a minor version bump
+  versionPolicyIntention := Compatibility.BinaryCompatible,
   crossScalaVersions := Seq("2.13.10", "2.12.17", "3.3.0"),
   scalaVersion := crossScalaVersions.value.head,
 )

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ ThisBuild / startYear := Some(2004)
 val commonSettings = Seq(
   versionScheme := Some("early-semver"),
   versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
-  crossScalaVersions := Seq("2.13.10", "2.12.17", "3.2.2"),
+  crossScalaVersions := Seq("2.13.10", "2.12.17", "3.3.0"),
   scalaVersion := crossScalaVersions.value.head,
 )
 
@@ -39,6 +39,7 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
         // not sure what resolving this would look like? didn't think about it too hard
         "-Wconf:site=scala.util.parsing.combinator.lexical.StdLexical.*&cat=other-match-analysis:i",
       )
+      case Some((3, _)) => Seq("Wunused:all")
       case _ => Seq()
     }),
     Compile / doc / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {

--- a/shared/src/test/scala/scala/util/parsing/combinator/LongestMatchTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/LongestMatchTest.scala
@@ -2,7 +2,6 @@ package scala.util.parsing.combinator
 
 import java.io.StringReader
 
-import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.StreamReader
 
 import org.junit.Test


### PR DESCRIPTION
The main goal here is to make sure we aren't getting any false positives, to help validate 3.3.0. ~-RC5. I had tried it with a previous RC and reported several bugs, but RC5 seems good.~

~Not for merge until 3.3.0 final comes.~ it's here