### PR TITLE
Update headers and NOTICE for lightbend name change

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,10 +1,10 @@
 Scala parser combinators
 Copyright (c) 2002-2024 EPFL
-Copyright (c) 2011-2024 Lightbend, Inc.
+Copyright (c) 2011-2024 Lightbend, Inc. dba Akka
 
 Scala includes software developed at
 LAMP/EPFL (https://lamp.epfl.ch/) and
-Lightbend, Inc. (https://www.lightbend.com/).
+Akka (https://akka.io/).
 
 Licensed under the Apache License, Version 2.0 (the "License").
 Unless required by applicable law or agreed to in writing, software

--- a/js/src/main/scala/scala/util/parsing/input/PositionCache.scala
+++ b/js/src/main/scala/scala/util/parsing/input/PositionCache.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/jvm/src/main/scala/scala/util/parsing/input/PositionCache.scala
+++ b/jvm/src/main/scala/scala/util/parsing/input/PositionCache.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/native/src/main/scala/scala/util/parsing/input/PositionCache.scala
+++ b/native/src/main/scala/scala/util/parsing/input/PositionCache.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala-2.13+/scala/util/parsing/input/ScalaVersionSpecificPagedSeq.scala
+++ b/shared/src/main/scala-2.13+/scala/util/parsing/input/ScalaVersionSpecificPagedSeq.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala-2.13-/scala/util/parsing/input/ScalaVersionSpecificPagedSeq.scala
+++ b/shared/src/main/scala-2.13-/scala/util/parsing/input/ScalaVersionSpecificPagedSeq.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/ImplicitConversions.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/ImplicitConversions.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/JavaTokenParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/JavaTokenParsers.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/PackratParsers.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/Parsers.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/RegexParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/RegexParsers.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/SubSequence.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/SubSequence.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/lexical/Lexical.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/lexical/Lexical.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/lexical/Scanners.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/lexical/Scanners.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/lexical/StdLexical.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/lexical/StdLexical.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/syntactical/StandardTokenParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/syntactical/StandardTokenParsers.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/syntactical/StdTokenParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/syntactical/StdTokenParsers.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/syntactical/TokenParsers.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/syntactical/TokenParsers.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/token/StdTokens.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/token/StdTokens.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/combinator/token/Tokens.scala
+++ b/shared/src/main/scala/scala/util/parsing/combinator/token/Tokens.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/input/CharArrayReader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/CharArrayReader.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/input/CharSequenceReader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/CharSequenceReader.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/input/NoPosition.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/NoPosition.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/OffsetPosition.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/input/PagedSeq.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/PagedSeq.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/input/PagedSeqReader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/PagedSeqReader.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/input/Position.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/Position.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/input/Positional.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/Positional.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/input/Reader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/Reader.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/main/scala/scala/util/parsing/input/StreamReader.scala
+++ b/shared/src/main/scala/scala/util/parsing/input/StreamReader.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/JavaTokenParsersTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/JavaTokenParsersTest.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/PackratParsersTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/PackratParsersTest.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/RegexParsersTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/RegexParsersTest.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh242.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh242.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh29.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh29.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh45.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh45.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh56.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh56.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/gh72.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/gh72.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/lexical/StdLexicalTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/lexical/StdLexicalTest.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/t0700.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t0700.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/t1100.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t1100.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/t1229.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t1229.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/t3212.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t3212.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/t4138.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t4138.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/t5514.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t5514.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/t5669.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t5669.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/t6067.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t6067.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/t6464.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t6464.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/t7483.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t7483.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/combinator/t8879.scala
+++ b/shared/src/test/scala/scala/util/parsing/combinator/t8879.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/input/OffsetPositionTest.scala
+++ b/shared/src/test/scala/scala/util/parsing/input/OffsetPositionTest.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/input/gh178.scala
+++ b/shared/src/test/scala/scala/util/parsing/input/gh178.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/shared/src/test/scala/scala/util/parsing/input/gh64.scala
+++ b/shared/src/test/scala/scala/util/parsing/input/gh64.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
The update in https://github.com/scala/scala-parser-combinators/pull/575 includes changes to the headers. See https://github.com/scala/sbt-scala-module/pull/205.