### PR TITLE
fix Scaladoc generation (and check it in CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         java-version: ${{matrix.java}}
     - uses: sbt/setup-sbt@v1
     - name: Test
-      run: sbt ++${{matrix.scala}} test headerCheck versionPolicyCheck package
+      run: sbt ++${{matrix.scala}} test doc headerCheck versionPolicyCheck package

--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,6 @@ lazy val parserCombinators = crossProject(JVMPlatform, JSPlatform, NativePlatfor
     // go nearly warning-free, but only on 2.13, it's too hard across all versions
     Compile / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 13)) => Seq("-Werror", "-Wunused",
-        // ideally we'd do something about this. `^?` is the responsible method
-        "-Wconf:site=scala.util.parsing.combinator.Parsers.*&cat=lint-multiarg-infix:i",
         // not sure what resolving this would look like? didn't think about it too hard
         "-Wconf:site=scala.util.parsing.combinator.lexical.StdLexical.*&cat=other-match-analysis:i",
       )


### PR DESCRIPTION
this came up in the Scala 2 community build

2.13.16 no longer has lint-multiarg-infix